### PR TITLE
Try to reduce flakiness on GitHub runners.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -47,3 +47,5 @@ jobs:
         run: python build.py
         env:
           USE_BAZEL_VERSION: ${{matrix.bazel}}
+          # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
+          BAZELISK_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Pass the provided token to Bazelisk so that we don’t run into rate limits.  See
https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467.