### PR TITLE
Use separate cache keys for repository cache.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -43,15 +43,22 @@ jobs:
           update: false
           release: false
         if: runner.os == 'Windows'
+      - name: Cache Bazel repositories
+        uses: actions/cache@v2
+        with:
+          path: ~/bazel-repository-cache
+          key: bazel-repositories-${{hashFiles('**/WORKSPACE', '**.bzl')}}
+          restore-keys: |
+            bazel-repositories-
       - name: Cache Bazel results
         uses: actions/cache@v2
         with:
-          path: ~/bazel-cache
-          key: bazel-${{runner.os}}-${{matrix.bazel}}-${{hashFiles('**')}}
+          path: ~/bazel-action-cache
+          key: bazel-actions-${{runner.os}}-${{matrix.bazel}}-${{hashFiles('**')}}
           restore-keys: |
-            bazel-${{runner.os}}-${{matrix.bazel}}-
-            bazel-${{runner.os}}-
-            bazel-
+            bazel-actions-${{runner.os}}-${{matrix.bazel}}-
+            bazel-actions-${{runner.os}}-
+            bazel-actions-
       - name: Run Bazel tests
         run: python build.py check
         env:

--- a/build.py
+++ b/build.py
@@ -155,9 +155,11 @@ def _bazel(command: str, targets: Iterable[str], *,
     args.extend(options)
     if github:
         # Use disk cache to speed up runs.
-        cache = pathlib.Path.home() / 'bazel-cache'
-        args += ['--disk_cache=' + str(cache / 'actions'),
-                 '--repository_cache=' + str(cache / 'repositories')]
+        home = pathlib.Path.home()
+        action_cache = home / 'bazel-action-cache'
+        repository_cache = home / 'bazel-repository-cache'
+        args += ['--disk_cache=' + str(action_cache),
+                 '--repository_cache=' + str(repository_cache)]
     if kernel == 'Windows':
         # We only support compilation using MinGW-64 at the moment.  Binaries
         # linked with the MinGW-64 linker will depend on a few libraries that


### PR DESCRIPTION
The repository cache should only depend on the contents of WORKSPACE and
Starlark files, but not on the OS and Bazel version,
cf. https://docs.bazel.build/versions/4.2.2/guide.html#the-repository-cache.
Right now the cache is so big that it’s always evicted.  Keying the repository
cache on WORKSPACE and Starlark file contents only should reduce the overall
cache size.