### PR TITLE
Update rules_python dependency.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,8 +38,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "rules_python",
-    sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
+    sha256 = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502",
+    strip_prefix = "rules_python-0.6.0",
+    url = "https://github.com/bazelbuild/rules_python/archive/0.6.0.tar.gz",
 )
 
 load("@//:internal.bzl", "requirements_txt")


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_python/releases/tag/0.6.0.