### PR TITLE
Add basic Gazelle support for Emacs Lisp.

### DIFF
--- a/docs/emacs.md
+++ b/docs/emacs.md
@@ -7,7 +7,7 @@ Defines the rule “emacs_binary”, which compiles Emacs for use in Bazel.
 ## emacs_binary
 
 <pre>
-emacs_binary(<a href="#emacs_binary-name">name</a>, <a href="#emacs_binary-dump_mode">dump_mode</a>, <a href="#emacs_binary-module_header">module_header</a>, <a href="#emacs_binary-readme">readme</a>, <a href="#emacs_binary-srcs">srcs</a>)
+emacs_binary(<a href="#emacs_binary-name">name</a>, <a href="#emacs_binary-builtin_features">builtin_features</a>, <a href="#emacs_binary-dump_mode">dump_mode</a>, <a href="#emacs_binary-module_header">module_header</a>, <a href="#emacs_binary-readme">readme</a>, <a href="#emacs_binary-srcs">srcs</a>)
 </pre>
 
 Builds Emacs from a source repository.
@@ -19,6 +19,7 @@ The resulting executable can be used to run the compiled Emacs.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="emacs_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="emacs_binary-builtin_features"></a>builtin_features |  Label for a file into which to write the list of builtin features.  If not provided, don’t write such a file. This is used by Gazelle.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |  |
 | <a id="emacs_binary-dump_mode"></a>dump_mode |  Dumping mode that Emacs will use.  This can be either  <code>portable</code> to use the portable dumper introduced in Emacs 27, or <code>unexec</code> to use the legacy “unexec” dumper.  Starting with Emacs 27, <code>portable</code> is strongly recommended.   | String | optional | "portable" |
 | <a id="emacs_binary-module_header"></a>module_header |  Label for a file target that will receive the <code>emacs-module.h</code> header.  If not provided, don’t install the header.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional |  |
 | <a id="emacs_binary-readme"></a>readme |  The README file in the root of the Emacs repository. This is necessary to determine the source root directory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |

--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021 Google LLC
+# Copyright 2020, 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -120,6 +120,7 @@ load("@phst_rules_elisp//emacs:defs.bzl", "emacs_binary")
 emacs_binary(
     name = "emacs",
     srcs = glob(["**"]),
+    builtin_features = "builtin_features.json",
     dump_mode = "{dump_mode}",
     module_header = {module_header},
     readme = "README",
@@ -136,6 +137,12 @@ emacs_binary(
 cc_library(
     name = "module_header",
     srcs = ["emacs-module.h"],
+    visibility = ["@phst_rules_elisp//emacs:__pkg__"],
+)
+
+filegroup(
+    name = "builtin_features",
+    srcs = ["builtin_features.json"],
     visibility = ["@phst_rules_elisp//emacs:__pkg__"],
 )
 """

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021 Google LLC
+# Copyright 2020, 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,12 @@ alias(
     name = "module_header",
     actual = "@gnu_emacs_27.2//:module_header",
     visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "builtin_features",
+    actual = "@gnu_emacs_27.2//:builtin_features",
+    visibility = ["//gazelle:__pkg__"],
 )
 
 alias(

--- a/emacs/defs.bzl
+++ b/emacs/defs.bzl
@@ -80,6 +80,11 @@ This is necessary to determine the source root directory.""",
             doc = """Label for a file target that will receive the
 `emacs-module.h` header.  If not provided, don’t install the header.""",
         ),
+        "builtin_features": attr.output(
+            doc = """Label for a file into which to write the list
+of builtin features.  If not provided, don’t write such a file.
+This is used by Gazelle.""",
+        ),
         "dump_mode": attr.string(
             default = "portable",
             values = ["portable", "unexec"],
@@ -199,6 +204,9 @@ def _install(ctx, cc_toolchain, source):
     if ctx.outputs.module_header:
         args.append("--module-header=" + ctx.outputs.module_header.path)
         outs.append(ctx.outputs.module_header)
+    if ctx.outputs.builtin_features:
+        args.append("--builtin-features=" + ctx.outputs.builtin_features.path)
+        outs.append(ctx.outputs.builtin_features)
     ctx.actions.run(
         outputs = outs,
         inputs = depset(

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,0 +1,79 @@
+# Copyright 2021, 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_gazelle//:def.bzl", "gazelle_binary")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+gazelle_binary(
+    name = "gazelle",
+    languages = [":go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "builtin.go",
+        "feature.go",
+        "generate.go",
+        "imports.go",
+        "language.go",
+        "loadpath.go",
+        "resolve.go",
+        "source.go",
+    ],
+    embedsrcs = ["builtin_features.json"],
+    importpath = "github.com/phst/rules_elisp/gazelle",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@bazel_gazelle//config:go_default_library",
+        "@bazel_gazelle//label:go_default_library",
+        "@bazel_gazelle//language:go_default_library",
+        "@bazel_gazelle//pathtools:go_default_library",
+        "@bazel_gazelle//repo:go_default_library",
+        "@bazel_gazelle//resolve:go_default_library",
+        "@bazel_gazelle//rule:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "gazelle_test.go",
+        "generate_test.go",
+        "imports_test.go",
+        "resolve_test.go",
+    ],
+    args = ["--gazelle=$(rootpath :gazelle)"],
+    data = [":gazelle"],
+    rundir = ".",
+    deps = [
+        ":go_default_library",
+        "@bazel_gazelle//label:go_default_library",
+        "@bazel_gazelle//language:go_default_library",
+        "@bazel_gazelle//repo:go_default_library",
+        "@bazel_gazelle//resolve:go_default_library",
+        "@bazel_gazelle//rule:go_default_library",
+        "@bazel_gazelle//testtools:go_default_library",
+        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_phst_runfiles//:go_default_library",
+    ],
+)
+
+copy_file(
+    name = "copy_builtin_features",
+    src = "//emacs:builtin_features",
+    out = "builtin_features.json",
+)

--- a/gazelle/builtin.go
+++ b/gazelle/builtin.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+var builtinFeatures = decodeBuiltinFeatures(builtinFeaturesJSON)
+
+func decodeBuiltinFeatures(b []byte) map[Feature]struct{} {
+	var data struct {
+		BuiltinFeatures []string `json:"builtinFeatures"`
+	}
+	if err := json.Unmarshal(b, &data); err != nil {
+		panic(fmt.Errorf("invalid builtin features JSON: %s", err))
+	}
+	if len(data.BuiltinFeatures) == 0 {
+		panic("no builtin features")
+	}
+	m := make(map[Feature]struct{}, len(data.BuiltinFeatures))
+	for _, f := range data.BuiltinFeatures {
+		m[Feature(f)] = struct{}{}
+	}
+	return m
+}
+
+//go:embed builtin_features.json
+var builtinFeaturesJSON []byte

--- a/gazelle/feature.go
+++ b/gazelle/feature.go
@@ -1,0 +1,37 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import "github.com/bazelbuild/bazel-gazelle/resolve"
+
+// Feature names an Emacs Lisp feature.  See
+// https://www.gnu.org/software/emacs/manual/html_node/elisp/Named-Features.html.
+// The empty Feature is invalid.
+type Feature string
+
+func (f Feature) valid() bool { return f != "" }
+
+func (f Feature) importSpec() resolve.ImportSpec {
+	return resolve.ImportSpec{
+		Lang: languageName,
+		Imp:  string(f),
+	}
+}
+
+type features []Feature
+
+func (f features) Len() int           { return len(f) }
+func (f features) Less(i, j int) bool { return f[i] < f[j] }
+func (f features) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }

--- a/gazelle/gazelle_test.go
+++ b/gazelle/gazelle_test.go
@@ -1,0 +1,124 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle_test
+
+import (
+	"flag"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/testtools"
+	"github.com/phst/runfiles"
+)
+
+var gazelleBinary = flag.String("gazelle", "", "location of the Gazelle binary")
+
+func TestGazelleBinary(t *testing.T) {
+	dir, clean := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path:    "WORKSPACE",
+			Content: `workspace(name = "test")`,
+		},
+		{
+			Path:    "empty.el",
+			Content: "",
+		},
+		{
+			Path: "lib-1.el",
+			Content: `
+(require 'lib-2)
+(provide 'lib-1)
+(provide 'foo)
+`,
+		},
+		{
+			Path: "lib-1-test.el",
+			Content: `
+(require 'lib-1)
+(ert-deftest lib-1-test ())
+(provide 'lib-1-test)
+`,
+		},
+		{
+			Path:    "pkg/lib-2.el",
+			Content: `(provide 'lib-2)`,
+		},
+		{
+			Path:    "a/b/lib-3.el",
+			Content: `(provide 'b/lib-3)`,
+		},
+	})
+	t.Cleanup(clean)
+
+	bin, err := runfiles.Path(path.Join("phst_rules_elisp", *gazelleBinary))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(bin, "update")
+	cmd.Dir = dir
+	t.Log("running Gazelle binary")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("Gazelle binary finished, output follows:\n%s", output)
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `load("@phst_rules_elisp//elisp:defs.bzl", "elisp_library", "elisp_test")
+
+elisp_library(
+    name = "empty",
+    srcs = ["empty.el"],
+)
+
+elisp_library(
+    name = "lib_1",
+    srcs = ["lib-1.el"],
+    deps = ["//pkg:lib_2"],
+)
+
+elisp_test(
+    name = "lib_1_test",
+    srcs = ["lib-1-test.el"],
+    deps = [":lib_1"],
+)
+`,
+		}, {
+			Path: "pkg/BUILD.bazel",
+			Content: `load("@phst_rules_elisp//elisp:defs.bzl", "elisp_library")
+
+elisp_library(
+    name = "lib_2",
+    srcs = ["lib-2.el"],
+    load_path = ["."],
+)
+`,
+		},
+		{
+			Path: "a/b/BUILD.bazel",
+			Content: `load("@phst_rules_elisp//elisp:defs.bzl", "elisp_library")
+
+elisp_library(
+    name = "lib_3",
+    srcs = ["lib-3.el"],
+    load_path = ["/a"],
+)
+`,
+		},
+	})
+}

--- a/gazelle/generate.go
+++ b/gazelle/generate.go
@@ -1,0 +1,126 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import (
+	"io/fs"
+	"log"
+	"os"
+	"regexp"
+	"sort"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// GenerateRules implements Language.GenerateRules.  It generates elisp_library
+// or elisp_test rules, one per source file.  It adds the features required by
+// each file to the GenerateResult.Imports slice as Imports structures.
+func (elisp) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	fsys := os.DirFS(args.Dir)
+	pkg := bazelPackage(args.Rel)
+	var res language.GenerateResult
+	for _, file := range args.RegularFiles {
+		// We generate exactly one rule per file.  This should work fine
+		// unless there are dependency cycles which cannot be resolved
+		// at compile time.
+		r, i := generateRule(fsys, pkg, file)
+		if r == nil {
+			continue
+		}
+		res.Gen = append(res.Gen, r)
+		res.Imports = append(res.Imports, i)
+	}
+	sort.Sort(byName(res)) // make output deterministic
+	return res
+}
+
+// generateRule generates a rule for a single Emacs Lisp source file.  fsys is a
+// filesystem for the Bazel workspace root containing the source file, pkg is
+// the name of the Bazel package (the empty string for the root package), and
+// file names the source file within the package.  Return nil if file doesn’t
+// name an Emacs Lisp file or on any error.
+func generateRule(fsys fs.FS, pkg bazelPackage, file string) (*rule.Rule, Imports) {
+	src := srcFile(label.New("", string(pkg), file))
+	if !src.valid() {
+		// Probably not an Emacs Lisp file.  Don’t print an error.
+		return nil, Imports{}
+	}
+	b, err := fs.ReadFile(fsys, file)
+	if err != nil {
+		log.Printf("unreadable source file %s: %s", file, err)
+		return nil, Imports{}
+	}
+	// We assume that most file are libraries and only assume a test file if
+	// the filename makes that likely.  We don’t look at the file contents
+	// at all: libraries can legitimately contain ‘ert-deftest’ forms, and
+	// we want to support empty files, too.  We never detect binaries: they
+	// are rather rare and hard to distinguish from libraries.
+	kind := libraryKind
+	if testFilePattern.MatchString(file) {
+		kind = testKind
+	}
+	var loadPath loadPath
+	if kind == libraryKind { // only libraries have a load path
+		loadPath = loadPathForFile(src, b)
+	}
+	r := rule.NewRule(kind, src.ruleName())
+	r.SetAttr("srcs", []string{file})
+	if len(loadPath) > 0 {
+		r.SetAttr("load_path", loadPath.attr(pkg))
+	}
+	// Also return required features.
+	requiresMap := make(map[Feature]struct{})
+	for _, m := range requirePattern.FindAllSubmatch(b, -1) {
+		feat := Feature(m[1])
+		if _, ok := builtinFeatures[feat]; ok {
+			continue
+		}
+		requiresMap[feat] = struct{}{}
+	}
+	var requires features
+	for f := range requiresMap {
+		requires = append(requires, f)
+	}
+	sort.Sort(requires)
+	return r, Imports{requires}
+}
+
+// Imports documents which features an Emacs Lisp file requires.
+// Language.GenerateRules uses this type for GenerateResult.Imports.
+type Imports struct {
+	Requires []Feature
+}
+
+var (
+	testFilePattern = regexp.MustCompile(`[-_](?:unit)?tests?\.el$`)
+	requirePattern  = regexp.MustCompile(`(?m)^\(require '([-/\w]+)\)`)
+)
+
+type byName language.GenerateResult
+
+func (s byName) Len() int {
+	return len(s.Gen)
+}
+
+func (s byName) Less(i, j int) bool {
+	return s.Gen[i].Name() < s.Gen[j].Name()
+}
+
+func (s byName) Swap(i, j int) {
+	s.Gen[i], s.Gen[j] = s.Gen[j], s.Gen[i]
+	s.Imports[i], s.Imports[j] = s.Imports[j], s.Imports[i]
+}

--- a/gazelle/generate_test.go
+++ b/gazelle/generate_test.go
@@ -1,0 +1,162 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/bazel-gazelle/testtools"
+	"github.com/bazelbuild/buildtools/build"
+	"github.com/google/go-cmp/cmp"
+	"github.com/phst/rules_elisp/gazelle"
+)
+
+func TestGenerateRules(t *testing.T) {
+	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{
+		{
+			Path:    "WORKSPACE",
+			Content: `workspace(name = "test")`,
+		},
+		{
+			Path:    "empty.el",
+			Content: "",
+		},
+		{
+			Path: "lib-1.el",
+			Content: `
+(require 'cl-lib)
+(require 'lib-2)
+(provide 'lib-1)
+(provide 'foo)
+`,
+		},
+		{
+			Path: "lib-1-test.el",
+			Content: `
+(require 'lib-1)
+(ert-deftest lib-1-test ())
+(provide 'lib-1-test)
+`,
+		},
+		{
+			Path:    "subdir/lib-2.el",
+			Content: `(provide 'lib-2)`,
+		},
+		{
+			Path:    "a/b/lib-3.el",
+			Content: `(provide 'b/lib-3)`,
+		},
+	})
+	t.Cleanup(cleanup)
+
+	lang := gazelle.NewLanguage()
+	cfg := testtools.NewTestConfig(t, nil, []language.Language{lang}, nil)
+
+	for _, tc := range []struct {
+		pkg   string
+		files []string
+		want  language.GenerateResult
+	}{
+		{
+			pkg:   "",
+			files: []string{"WORKSPACE", "lib-1.el", "lib-1-test.el", "empty.el", "nonexisting.el"},
+			want: language.GenerateResult{
+				Gen: []*rule.Rule{
+					newRule("elisp_library", "empty", []string{"empty.el"}, nil),
+					newRule("elisp_library", "lib_1", []string{"lib-1.el"}, nil),
+					newRule("elisp_test", "lib_1_test", []string{"lib-1-test.el"}, nil),
+				},
+				Imports: []interface{}{
+					gazelle.Imports{},
+					gazelle.Imports{Requires: []gazelle.Feature{"lib-2"}},
+					gazelle.Imports{Requires: []gazelle.Feature{"lib-1"}},
+				},
+			},
+		},
+		{
+			pkg:   "subdir",
+			files: []string{"lib-2.el"},
+			want: language.GenerateResult{
+				Gen: []*rule.Rule{
+					newRule("elisp_library", "lib_2", []string{"lib-2.el"}, []string{"."}),
+				},
+				Imports: []interface{}{gazelle.Imports{}},
+			},
+		},
+		{
+			pkg:   "a/b",
+			files: []string{"lib-3.el"},
+			want: language.GenerateResult{
+				Gen: []*rule.Rule{
+					newRule("elisp_library", "lib_3", []string{"lib-3.el"}, []string{"/a"}),
+				},
+				Imports: []interface{}{gazelle.Imports{}},
+			},
+		},
+	} {
+		t.Run(tc.pkg, func(t *testing.T) {
+			args := language.GenerateArgs{
+				Config:       cfg,
+				Dir:          filepath.Join(dir, filepath.FromSlash(tc.pkg)),
+				Rel:          tc.pkg,
+				RegularFiles: tc.files,
+			}
+			got := lang.GenerateRules(args)
+			if diff := cmp.Diff(got, tc.want, cmp.Transformer("", transformRule)); diff != "" {
+				t.Error("-got +want:\n", diff)
+			}
+		})
+	}
+}
+
+func newRule(kind, name string, srcs, loadPath []string) *rule.Rule {
+	r := rule.NewRule(kind, name)
+	if srcs != nil {
+		r.SetAttr("srcs", srcs)
+	}
+	if loadPath != nil {
+		r.SetAttr("load_path", loadPath)
+	}
+	return r
+}
+
+func transformRule(r *rule.Rule) ruleInfo {
+	i := ruleInfo{
+		Kind:        r.Kind(),
+		Name:        r.Name(),
+		Args:        r.Args(),
+		Attr:        make(map[string]build.Expr),
+		PrivateAttr: make(map[string]interface{}),
+		Comments:    r.Comments(),
+	}
+	for _, k := range r.AttrKeys() {
+		i.Attr[k] = r.Attr(k)
+	}
+	for _, k := range r.PrivateAttrKeys() {
+		i.PrivateAttr[k] = r.PrivateAttr(k)
+	}
+	return i
+}
+
+type ruleInfo struct {
+	Kind, Name  string
+	Args        []build.Expr
+	Attr        map[string]build.Expr
+	PrivateAttr map[string]interface{}
+	Comments    []string
+}

--- a/gazelle/imports.go
+++ b/gazelle/imports.go
@@ -1,0 +1,82 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import (
+	"log"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/pathtools"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// Imports implements Resolver.Imports.  For an elisp_library rule, it returns
+// the features that the source files likely provide.  It doesn’t actually parse
+// the source files.
+func (elisp) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	if r.Kind() != libraryKind {
+		return nil
+	}
+	pkg := bazelPackage(f.Pkg)
+	srcs := r.AttrStrings("srcs")
+	load := loadPathFromAttr(r.AttrStrings("load_path"), pkg)
+	imports := []resolve.ImportSpec{} // never nil
+	for _, src := range srcs {
+		lbl, err := label.Parse(src)
+		if err != nil {
+			log.Printf("invalid source filename %q: %s", src, err)
+			continue
+		}
+		src := srcFile(lbl.Abs("", string(pkg)))
+		if !src.valid() {
+			continue
+		}
+		feat := potentialProvides(src, load)
+		imports = append(imports, feat...)
+	}
+	return imports
+}
+
+// potentialProvides returns the features that the file might provide, assuming
+// the load path is loadPath.
+func potentialProvides(file sourceFile, loadPath loadPath) []resolve.ImportSpec {
+	var r []resolve.ImportSpec
+	for _, dir := range loadPath {
+		feat := potentialProvide(file, dir)
+		if !feat.valid() {
+			// The source file is not within the load path element.
+			continue
+		}
+		r = append(r, feat.importSpec())
+	}
+	return r
+}
+
+// potentialProvide returns the name of the feature that the file might provide,
+// assuming dir is a directory in the load path.  It returns the empty string if
+// there is no such feature.
+func potentialProvide(file sourceFile, dir loadDirectory) Feature {
+	stem := file.stem()
+	if dir == "." {
+		return Feature(stem)
+	}
+	s := pathtools.TrimPrefix(stem, string(dir))
+	if s == stem {
+		return ""
+	}
+	return Feature(s)
+}

--- a/gazelle/imports_test.go
+++ b/gazelle/imports_test.go
@@ -1,0 +1,120 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle_test
+
+import (
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/bazel-gazelle/testtools"
+	"github.com/google/go-cmp/cmp"
+	"github.com/phst/rules_elisp/gazelle"
+)
+
+func TestImports(t *testing.T) {
+	lang := gazelle.NewLanguage()
+	config := testtools.NewTestConfig(t, nil, []language.Language{lang}, nil)
+	for _, tc := range []struct {
+		desc, pkg, build string
+		want             []resolve.ImportSpec
+	}{
+		{
+			desc:  "unrelated rule kind",
+			build: `cc_library(name = "lib", srcs = ["lib.cc"])`,
+			want:  nil,
+		},
+		{
+			desc: "root package",
+			pkg:  "",
+			build: `elisp_library(
+    name = "lib",
+    srcs = [
+        "lib.el",
+        "subdir/file.el",
+        "//other:qux.el",
+        "@external//:bar.el",
+    ],
+    load_path = ["subdir", "/other", "/unrelated"],
+)`,
+			want: []resolve.ImportSpec{
+				{Lang: "elisp", Imp: "lib"},
+				{Lang: "elisp", Imp: "subdir/file"},
+				{Lang: "elisp", Imp: "file"},
+				{Lang: "elisp", Imp: "other/qux"},
+				{Lang: "elisp", Imp: "qux"},
+			},
+		},
+		{
+			desc: "subpackage",
+			pkg:  "lib",
+			build: `elisp_library(
+    name = "lib",
+    srcs = [
+        "lib.el",
+        "subdir/file.el",
+        "//other:qux.el",
+        "@external//:bar.el",
+    ],
+    load_path = [".", "/other", "/unrelated"],
+)`,
+			want: []resolve.ImportSpec{
+				{Lang: "elisp", Imp: "lib/lib"},
+				{Lang: "elisp", Imp: "lib"},
+				{Lang: "elisp", Imp: "lib/subdir/file"},
+				{Lang: "elisp", Imp: "subdir/file"},
+				{Lang: "elisp", Imp: "other/qux"},
+				{Lang: "elisp", Imp: "qux"},
+			},
+		},
+		{
+			desc: "no custom load path",
+			pkg:  "lib",
+			build: `elisp_library(
+    name = "lib",
+    srcs = ["lib.el", "subdir/file.el"],
+)`,
+			want: []resolve.ImportSpec{
+				{Lang: "elisp", Imp: "lib/lib"},
+				{Lang: "elisp", Imp: "lib/subdir/file"},
+			},
+		},
+		{
+			desc:  "no source files",
+			pkg:   "lib",
+			build: `elisp_library(name = "lib", srcs = [])`,
+			want:  []resolve.ImportSpec{},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fileName := filepath.FromSlash(path.Join("/workspace", tc.pkg, "BUILD"))
+			f, err := rule.LoadData(fileName, tc.pkg, []byte(tc.build))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n := len(f.Rules); n != 1 {
+				t.Fatalf("got %d rules in BUILD file, want one", n)
+			}
+			r := f.Rules[0]
+			got := lang.Imports(config, r, f)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Error("-got +want:\n", diff)
+			}
+		})
+	}
+}

--- a/gazelle/language.go
+++ b/gazelle/language.go
@@ -1,0 +1,96 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gazelle implements Gazelle support for Emacs Lisp.  It generates and
+// maintains elisp_library and elisp_test rules from the phst_rules_elisp
+// workspace.  See https://phst.eu/rules_elisp/ and
+// https://github.com/bazelbuild/bazel-gazelle/blob/master/extend.md.
+package gazelle
+
+import (
+	"flag"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// NewLanguage returns a Gazelle language object for Emacs Lisp.
+func NewLanguage() language.Language {
+	return elisp{}
+}
+
+const languageName = "elisp"
+
+type elisp struct{}
+
+func (elisp) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
+
+func (elisp) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
+
+func (elisp) KnownDirectives() []string { return nil }
+
+func (elisp) Configure(c *config.Config, rel string, f *rule.File) {
+	// We always rely on the imports index to write deps attributes.
+	c.IndexLibraries = true
+}
+
+func (elisp) Name() string { return languageName }
+
+func (elisp) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
+
+func (elisp) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		libraryKind: {
+			NonEmptyAttrs: map[string]bool{
+				"src":       true,
+				"deps":      true,
+				"load_path": true,
+			},
+			ResolveAttrs: map[string]bool{"deps": true},
+		},
+		binaryKind: {
+			NonEmptyAttrs: map[string]bool{
+				"srcs": true,
+				"deps": true,
+			},
+			MergeableAttrs: map[string]bool{"srcs": true},
+			ResolveAttrs:   map[string]bool{"deps": true},
+		},
+		testKind: {
+			NonEmptyAttrs: map[string]bool{
+				"srcs": true,
+				"deps": true,
+			},
+			MergeableAttrs: map[string]bool{"srcs": true},
+			ResolveAttrs:   map[string]bool{"deps": true},
+		},
+	}
+}
+
+func (elisp) Loads() []rule.LoadInfo {
+	return []rule.LoadInfo{{
+		Name:    "@phst_rules_elisp//elisp:defs.bzl",
+		Symbols: []string{libraryKind, binaryKind, testKind},
+	}}
+}
+
+func (elisp) Fix(c *config.Config, f *rule.File) {}
+
+const (
+	libraryKind = "elisp_library"
+	binaryKind  = "elisp_binary"
+	testKind    = "elisp_test"
+)

--- a/gazelle/loadpath.go
+++ b/gazelle/loadpath.go
@@ -1,0 +1,127 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import (
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/pathtools"
+)
+
+// loadDirectory names a directory in the Emacs load path.  See
+// https://www.gnu.org/software/emacs/manual/html_node/emacs/Lisp-Libraries.html.
+// By convention, a load directory is a nonempty clean slash-separated directory
+// name (without leading or trailing slash) relative to the main workspace root.
+// The main workspace root itself is represented using a single dot.  An empty
+// load directory is invalid.
+type loadDirectory string
+
+// loadDirFromAttr returns the load directory that corresponds to the given
+// load_path attribute element, assuming the package of the surrounding rule is
+// pkg.
+func loadDirFromAttr(attr string, pkg bazelPackage) loadDirectory {
+	if path.IsAbs(attr) {
+		return loadDirectory(strings.TrimPrefix(path.Clean(attr), "/"))
+	} else {
+		return loadDirectory(path.Join(string(pkg), attr))
+	}
+}
+
+// loadDirForFile returns the load directory that would be needed so that the
+// file can provide the feature and can be found using a one-argument require
+// form.  It returns the empty string if there is no such directory.
+func loadDirForFile(file sourceFile, feat Feature) loadDirectory {
+	stem := "/" + file.stem()
+	suffix := "/" + string(feat)
+	dir := strings.TrimSuffix(stem, suffix)
+	if dir == stem {
+		return ""
+	}
+	return loadDirectory(strings.TrimPrefix(dir, "/"))
+}
+
+func (d loadDirectory) valid() bool { return d != "" }
+
+// attr returns the value that the load_path element for this directory should
+// have within the given package.
+func (d loadDirectory) attr(pkg bazelPackage) string {
+	s := string(d)
+	suffix := pathtools.TrimPrefix(s, string(pkg))
+	if suffix == s {
+		return "/" + s
+	}
+	return path.Clean(suffix)
+}
+
+// loadPath represents the Emacs load path, an ordered sequence of directories.
+type loadPath []loadDirectory
+
+// loadPathForFile returns the load path that would be needed to be able to load
+// the given file with a one-argument require form given any of the provided
+// features within the file.
+func loadPathForFile(name sourceFile, content []byte) loadPath {
+	dirs := make(map[loadDirectory]struct{})
+	for _, m := range providePattern.FindAllSubmatch(content, -1) {
+		feat := Feature(m[1])
+		// Ignore features that couldn’t be used with a simple ‘require’
+		// form.  Only if the file name is of the form “FEATURE” or
+		// “DIR/FEATURE”, we can ‘require’ the feature from this file.
+		// In the latter case, we need DIR in the load path.
+		dir := loadDirForFile(name, feat)
+		if !dir.valid() {
+			continue
+		}
+		dirs[dir] = struct{}{}
+	}
+	var r loadPath
+	for dir := range dirs {
+		r = append(r, dir)
+	}
+	sort.Sort(r)
+	return r
+}
+
+var providePattern = regexp.MustCompile(`(?m)^\(provide '([-/\w]+)\)`)
+
+// loadDirFromAttr returns the load path that corresponds to the given load_path
+// attribute value, assuming the package of the surrounding rule is pkg.
+func loadPathFromAttr(attr []string, pkg bazelPackage) loadPath {
+	r := loadPath{"."} // implicitly added
+	for _, s := range attr {
+		r = append(r, loadDirFromAttr(s, pkg))
+	}
+	return r
+}
+
+func (p loadPath) Len() int           { return len(p) }
+func (p loadPath) Less(i, j int) bool { return p[i] < p[j] }
+func (p loadPath) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// attr returns the corresponding value for load_path attributes within the
+// given package.
+func (p loadPath) attr(pkg bazelPackage) []string {
+	var r []string
+	for _, d := range p {
+		s := d.attr(pkg)
+		if s == "/" { // implicitly added
+			continue
+		}
+		r = append(r, s)
+	}
+	return r
+}

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -1,0 +1,57 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import (
+	"log"
+	"sort"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// Resolve implements Resolver.Resolve.  It adds a deps attribute to the given
+// rule.  imports should be an Imports object, and ix should contain mappings
+// for the features in imports.
+func (elisp) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+	imp, ok := imports.(Imports)
+	if !ok {
+		return
+	}
+	var deps []string
+	for _, feat := range imp.Requires {
+		spec := feat.importSpec()
+		res := ix.FindRulesByImportWithConfig(c, spec, languageName)
+		if len(res) == 0 {
+			log.Printf("%s: no rule for required feature %s found", from, feat)
+			continue
+		}
+		if len(res) > 1 {
+			log.Printf("%s: %d rules for required feature %s found", from, len(res), feat)
+		}
+		// Make the label relative to the current package if possible.
+		lbl := res[0].Label.Rel(from.Repo, from.Pkg)
+		deps = append(deps, lbl.String())
+	}
+	if len(deps) > 0 {
+		sort.Strings(deps)
+		r.SetAttr("deps", deps)
+	} else {
+		r.DelAttr("deps")
+	}
+}

--- a/gazelle/resolve_test.go
+++ b/gazelle/resolve_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazelbuild/bazel-gazelle/testtools"
+	"github.com/google/go-cmp/cmp"
+	"github.com/phst/rules_elisp/gazelle"
+)
+
+func TestResolve(t *testing.T) {
+	lang := gazelle.NewLanguage()
+	cfg := testtools.NewTestConfig(t, nil, []language.Language{lang}, nil)
+	build, err := rule.LoadData("pkg/BUILD", "pkg", []byte(`
+elisp_library(
+    name = "lib",
+    srcs = ["lib.el"],
+    load_path = ["."],
+)
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(build.Rules) != 1 {
+		t.Fatalf("got %d rules, want one", len(build.Rules))
+	}
+	ix := resolve.NewRuleIndex(func(*rule.Rule, string) resolve.Resolver { return lang })
+	ix.AddRule(cfg, build.Rules[0], build)
+	ix.Finish()
+	rc, cleanup := repo.NewRemoteCache(nil)
+	defer cleanup()
+	testRule := rule.NewRule("elisp_test", "lib_test")
+	imports := gazelle.Imports{Requires: []gazelle.Feature{"lib"}}
+	lbl := label.New("", "pkg", "lib_test")
+
+	lang.Resolve(cfg, ix, rc, testRule, imports, lbl)
+
+	got := testRule.AttrStrings("deps")
+	want := []string{":lib"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error("-got +want:\n", diff)
+	}
+}

--- a/gazelle/source.go
+++ b/gazelle/source.go
@@ -1,0 +1,62 @@
+// Copyright 2021, 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gazelle
+
+import (
+	"path"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/label"
+)
+
+// sourceFile names an Emacs Lisp source file.  By convention, it’s a
+// slash-separated clean filename relative to the main workspace root.  The
+// extension should always be “.el”.
+type sourceFile string
+
+const sourceExt = ".el"
+
+// srcFile returns the source file for the given label.  The label must be
+// absolute.  srcFile returns an empty string if the label isn’t in the main
+// workspace or doesn’t refer to an Emacs Lisp source file.
+func srcFile(lbl label.Label) sourceFile {
+	if lbl.Repo != "" {
+		// Currently we don’t support sources from other repositories.
+		return ""
+	}
+	if path.Ext(lbl.Name) != sourceExt {
+		// Not an Emacs Lisp source file.
+		return ""
+	}
+	return sourceFile(path.Join(lbl.Pkg, lbl.Name))
+}
+
+func (f sourceFile) valid() bool { return f != "" }
+
+// stem returns the filename without extension.
+func (f sourceFile) stem() string {
+	return strings.TrimSuffix(string(f), sourceExt)
+}
+
+// ruleName returns a suggestion for a rule name that consumes the receiver
+// file.
+func (f sourceFile) ruleName() string {
+	return strings.ReplaceAll(path.Base(f.stem()), "-", "_")
+}
+
+// bazelPackage names a Bazel package.  It’s typically a slash-separated
+// directory name within a workspace.  The empty package name is valid and
+// refers to the root package.
+type bazelPackage string


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-gazelle/blob/master/extend.md.