### PR TITLE
Install missing MSYS2 packages.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -44,6 +44,11 @@ jobs:
         with:
           update: false
           release: false
+          # See nt/INSTALL.W64 for the list of required MSYS2 packages
+          install: >
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-xpm-nox
         if: runner.os == 'Windows'
       - name: Cache Bazel repositories
         uses: actions/cache@v2


### PR DESCRIPTION
It seems that they are now missing from the default runner installation.