### PR TITLE
Don’t copy file permissions into temporary workspace.

### DIFF
--- a/check_python.py
+++ b/check_python.py
@@ -34,7 +34,7 @@ class Workspace:
         for file in params['srcs']:
             dest = tempdir / workspace_name / file['rel']
             dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(file['src'], dest)
+            shutil.copyfile(file['src'], dest)
             # Don’t attempt to check generated protocol buffer files.
             if not file['ext'] and not dest.name.endswith('_pb2.py'):
                 srcs.append(dest)


### PR DESCRIPTION
Otherwise removing the copies might fail later if they come from an external
workspace.