### PR TITLE
Explicitly specify Visual C++ location.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -87,5 +87,7 @@ jobs:
           -- check
         env:
           USE_BAZEL_VERSION: ${{matrix.bazel}}
+          BAZEL_VC: >-
+            C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC
           # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
           BAZELISK_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This is necessary because on the GitHub runner Visual C++ 2022 is also
installed, but doesn’t work with Bazel.