### PR TITLE
Remove support for MinGW and Clang on Windows.

### DIFF
--- a/constraints/BUILD
+++ b/constraints/BUILD
@@ -31,13 +31,3 @@ config_setting(
     name = "msvc-cl",
     flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
 )
-
-config_setting(
-    name = "clang-cl",
-    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang-cl"},
-)
-
-config_setting(
-    name = "mingw-gcc",
-    flag_values = {"@bazel_tools//tools/cpp:compiler": "mingw-gcc"},
-)

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -149,39 +149,21 @@ bzl_library(
 )
 
 LAUNCHER_FEATURES = select({
-    "//constraints:mingw-gcc": [
-        # keep sorted
-        "fully_static_link",
-        "static_linking_mode",
-    ],
     "//conditions:default": [],
 })
 
 LAUNCHER_DEFINES = DEFINES
 
 LAUNCHER_COPTS = COPTS + CXXOPTS + select({
-    "//constraints:mingw-gcc": [
-        "-mwin32",
-        "-municode",
-        "-mconsole",
-    ],
     "//conditions:default": [],
 })
 
 LINKOPTS = select({
-    "//constraints:mingw-gcc": [
-        "-limagehlp",  # https://stackoverflow.com/a/26513179
-    ],
     "//conditions:default": [],
 })
 
 LAUNCHER_LINKOPTS = LINKOPTS + select({
     "//constraints:msvc-cl": ["/SUBSYSTEM:CONSOLE"],
-    "//constraints:mingw-gcc": [
-        "-mwin32",
-        "-municode",
-        "-mconsole",
-    ],
     "//conditions:default": [],
 })
 


### PR DESCRIPTION
We now only use Visual C++ in the CI system, so these combinations are untested.