### PR TITLE
Add support for newly-released Emacs 28.1.

### DIFF
--- a/build.py
+++ b/build.py
@@ -266,19 +266,19 @@ class Builder:
 
 def _versions() -> FrozenSet[str]:
     # All potentially supported Emacs versions.
-    ret = {'26.1', '26.2', '26.3', '27.1', '27.2'}
+    ret = {'26.1', '26.2', '26.3', '27.1', '27.2', '28.1'}
     uname = platform.uname()
     if uname.system == 'Linux':
         # GNU/Linux supports all Emacs versions.
         pass
     elif uname.system == 'Darwin':
-        # macOS only supports Emacs 27.
+        # macOS only supports Emacs 27 and later.
         ret -= {'26.1', '26.2', '26.3'}
         if uname.machine != 'x86_64':
             # Apple Silicon doesn’t support Emacs 27.1.
             ret.remove('27.1')
     elif uname.system == 'Windows':
-        # Windows only supports Emacs 27.
+        # Windows only supports Emacs 27 and later.
         ret -= {'26.1', '26.2', '26.3'}
     else:
         raise ValueError(f'unsupported kernel {uname.system}')

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -59,6 +59,12 @@ toolchain(
 )
 
 toolchain(
+    name = "emacs_28.1_toolchain",
+    toolchain = "emacs_28.1",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
     name = "local_toolchain",
     toolchain = ":local",
     toolchain_type = ":toolchain_type",
@@ -98,6 +104,11 @@ elisp_toolchain(
 elisp_toolchain(
     name = "emacs_27.2",
     emacs = "//emacs:emacs_27.2",
+)
+
+elisp_toolchain(
+    name = "emacs_28.1",
+    emacs = "//emacs:emacs_28.1",
 )
 
 exports_files([

--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -72,6 +72,16 @@ def rules_elisp_dependencies():
         ],
     )
     http_archive(
+        name = "gnu_emacs_28.1",
+        build_file_content = _build_file(macos_arm = True, portable = True),
+        sha256 = "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1",
+        strip_prefix = "emacs-28.1/",
+        urls = [
+            "https://ftpmirror.gnu.org/emacs/emacs-28.1.tar.xz",
+            "https://ftp.gnu.org/gnu/emacs/emacs-28.1.tar.xz",
+        ],
+    )
+    http_archive(
         name = "bazel_skylib",
         sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
         urls = [
@@ -173,6 +183,7 @@ alias(
         "@gnu_emacs_26.3//:__pkg__",
         "@gnu_emacs_27.1//:__pkg__",
         "@gnu_emacs_27.2//:__pkg__",
+        "@gnu_emacs_28.1//:__pkg__",
     ],
 )
 """
@@ -190,6 +201,7 @@ cc_toolchain_suite(
         "@gnu_emacs_26.3//:__pkg__",
         "@gnu_emacs_27.1//:__pkg__",
         "@gnu_emacs_27.2//:__pkg__",
+        "@gnu_emacs_28.1//:__pkg__",
     ],
 )
 """

--- a/elisp/runfiles/runfiles-test.el
+++ b/elisp/runfiles/runfiles-test.el
@@ -1,6 +1,6 @@
 ;;; runfiles-test.el --- unit test for runfiles.el  -*- lexical-binding: t; -*-
 
-;; Copyright 2020, 2021 Google LLC
+;; Copyright 2020, 2021, 2022 Google LLC
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -92,6 +92,8 @@
                     "/bazel-runfile:phst_rules_elisp/elisp/runfiles/test.txt"
                     "/bazel-runfile:phst_rules_elisp/elisp/")
                    "runfiles/test.txt"))
+    (should (equal (file-truename "/bazel-runfile:phst_rules_elisp/elisp/")
+                   "/bazel-runfile:phst_rules_elisp/elisp/"))
     (let ((load-path '("/bazel-runfile:phst_rules_elisp")))
       (require 'elisp/runfiles/test-lib))))
 

--- a/elisp/runfiles/runfiles.el
+++ b/elisp/runfiles/runfiles.el
@@ -324,7 +324,7 @@ FILENAME."
     (file-name-sans-versions arg arg)
     (file-selinux-context file)
     (file-symlink-p file noerror)
-    (file-truename file)
+    (file-truename arg)
     (insert-directory file arg arg arg)
     (insert-file-contents file arg arg arg arg)
     (load file arg arg arg arg)

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -75,6 +75,12 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+alias(
+    name = "emacs_28.1",
+    actual = "@gnu_emacs_28.1//:emacs",
+    visibility = ["//visibility:public"],
+)
+
 py_binary(
     name = "build",
     srcs = ["build.py"],
@@ -209,6 +215,7 @@ constraint_value(
         "@gnu_emacs_26.3//:__pkg__",
         "@gnu_emacs_27.1//:__pkg__",
         "@gnu_emacs_27.2//:__pkg__",
+        "@gnu_emacs_28.1//:__pkg__",
     ],
 )
 
@@ -234,5 +241,6 @@ cc_defaults(
         "@gnu_emacs_26.3//:__pkg__",
         "@gnu_emacs_27.1//:__pkg__",
         "@gnu_emacs_27.2//:__pkg__",
+        "@gnu_emacs_28.1//:__pkg__",
     ],
 )


### PR DESCRIPTION
See https://lists.gnu.org/archive/html/emacs-devel/2022-04/msg00093.html.