### PR TITLE
Use keyword-only form for :noinline structure option.

### DIFF
--- a/elisp/proto/generate.el
+++ b/elisp/proto/generate.el
@@ -72,7 +72,7 @@ This type corresponds to the protocol buffer message type ‘%s’."
                         (:conc-name ,conc-name)
                         (:constructor ,private-constructor (arena ptr))
                         (:include elisp/proto/message)
-                        (:noinline t))
+                        :noinline)
            ,struct-doc))
     (terpri)
     (pp `(defun ,public-constructor (,@(and fields '(&rest fields)))

--- a/elisp/proto/proto.el
+++ b/elisp/proto/proto.el
@@ -32,7 +32,7 @@
                (:constructor nil)
                (:copier nil)
                (:predicate nil)
-               (:noinline t))
+               :noinline)
   "Internal base type for protocol buffer objects.
 This type is internal and should not be used directly."
   (arena nil :type user-ptr :read-only t)
@@ -43,7 +43,7 @@ This type is internal and should not be used directly."
                (:constructor nil)
                (:copier nil)
                (:include elisp/proto/object)
-               (:noinline t))
+               :noinline)
   "Base type for generated protocol buffer messages.
 The fields are internal and should not be accessed directly.")
 
@@ -129,7 +129,7 @@ in the Info node ‘(elisp) Output Streams’."
                (:constructor elisp/proto/array--new (arena ptr))
                (:copier nil)
                (:include elisp/proto/object)
-               (:noinline t))
+               :noinline)
   "Wraps a protocol buffer message array.
 Such an array is typically the result of obtaining the value of a
 repeated field using ‘elisp/proto/field’ or
@@ -222,7 +222,7 @@ TYPE specifies the return type, one of ‘vector’, ‘string’, or ‘list’
                (:constructor elisp/proto/map--new (arena ptr))
                (:copier nil)
                (:include elisp/proto/object)
-               (:noinline t))
+               :noinline)
   "Wraps a protocol buffer message array.
 Such an array is typically the result of obtaining the value of a
 map field using ‘elisp/proto/field’ or

--- a/elisp/runfiles/runfiles.el
+++ b/elisp/runfiles/runfiles.el
@@ -34,7 +34,7 @@
                (:conc-name elisp/runfiles/runfiles--)
                (:constructor elisp/runfiles/runfiles--make (impl))
                (:copier nil)
-               (:noinline t))
+               :noinline)
   "Provides access to Bazel runfiles.
 Use ‘elisp/runfiles/make’ to create instances of
 ‘elisp/runfiles/runfiles’, or ‘elisp/runfiles/get’ access a


### PR DESCRIPTION
Edebug doesn’t detect the list form before commit
f3df7916b2b342380930082cf35bad6cb488a4dc, and that commit is not present in any
released version of Emacs.