### PR TITLE
Use per-platform pip requirements.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,15 +43,14 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz",
 )
 
-load("@//private:defs.bzl", "requirements_txt")
-
-requirements_txt(name = "requirements_txt")
-
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
     name = "pip_deps",
-    requirements_lock = "@requirements_txt//:requirements.txt",
+    requirements_darwin = "@//:macos-requirements.txt",
+    requirements_linux = "@//:linux-requirements.txt",
+    requirements_lock = None,
+    requirements_windows = "@//:windows-requirements.txt",
 )
 
 load("@pip_deps//:requirements.bzl", "install_deps")

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -18,32 +18,6 @@ These definitions are internal and subject to change without notice."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def _requirements_txt_impl(repository_ctx):
-    """Implementation of the “copy_requirements_txt” repository rule."""
-    prefixes = {
-        "linux": "linux",
-        "mac os x": "macos",
-        "windows server 2019": "windows",
-    }
-    prefix = prefixes.get(repository_ctx.os.name, None)
-    if not prefix:
-        fail("Unsupported operating system “{}”".format(repository_ctx.os.name))
-    repository_ctx.symlink(
-        Label("@//:{}-requirements.txt".format(prefix)),
-        "requirements.txt",
-    )
-    repository_ctx.file(
-        "BUILD",
-        'exports_files(["requirements.txt"])',
-        executable = False,
-    )
-
-requirements_txt = repository_rule(
-    implementation = _requirements_txt_impl,
-    local = True,
-    doc = "Generates requirements.txt for the current platform.",
-)
-
 def _check_python_impl(target, ctx):
     tags = ctx.rule.attr.tags
     if "no-python-check" in tags:


### PR DESCRIPTION
These are now natively supported by rules_python,
cf. https://github.com/bazelbuild/rules_python/pull/531.  This means we can now
remove our hand-rolled support for per-platform requirements.