### PR TITLE
Drop support for Bazel 4 and 5.0.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        bazel: [4.2.1, 4.2.2, 5.0.0, 5.1.0, 5.1.1, 5.2.0, latest, rolling]
+        bazel: [5.1.0, 5.1.1, 5.2.0, latest, rolling]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           # FIXME: Investigate why this fails.  See

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 # Note that the versions library only works within a WORKSPACE file, see
 # https://github.com/bazelbuild/bazel/issues/8305.
-versions.check("4.2.1")
+versions.check("5.1.0")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/docs/manual.org
+++ b/docs/manual.org
@@ -39,7 +39,7 @@ This is not an officially supported Google product.
 To use ~rules_elisp~, you need [[https://bazel.build/][Bazel]].  For
 installation instructions, see [[https://bazel.build/install][Installing
 Bazel]].  This repository supports all full Bazel releases starting with Bazel
-4.2.1.  You’ll also need a recent C/C++ compiler (GCC or Clang on GNU/Linux and
+5.1.0.  You’ll also need a recent C/C++ compiler (GCC or Clang on GNU/Linux and
 macOS, Visual C++ 2019 on Windows) and at least Python 3.9.  For further
 instructions how to use Bazel on Windows, see
 [[https://bazel.build/install/windows][Installing Bazel on Windows]].  On


### PR DESCRIPTION
The µpb dependency now requires at least Bazel 5.1.