### PR TITLE
Use protocol buffer dependency through µpb.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dummy package to make µpb happy.  This will be deleted once we import past
+# https://github.com/protocolbuffers/upb/commit/23048df5259ab99a45918738adb534405e4da1a5.

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -1,0 +1,24 @@
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--- BUILD.bazel	2022-05-09 19:06:30.000000000 +0200
++++ BUILD.bazel	2022-09-28 10:08:20.198842822 +0200
+@@ -939,6 +939,7 @@
+             ":python/google/protobuf/pyext/_message.so",
+         ],
+     }),
++    visibility = ["//visibility:public"],
+     deps = [
+         ":python_srcs",
+         ":well_known_types_py_pb2",

--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -93,15 +93,9 @@ def rules_elisp_dependencies():
             "https://github.com/protocolbuffers/upb/archive/83f4988561baf5951bce6f07ddaa1cb325ba0241.zip",  # 2022-06-23
         ],
     )
-    maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        sha256 = "f10a175c9492847729a4eef787e85698b8f3ee83394a1a1d1d9f48f8835b74cf",
-        strip_prefix = "protobuf-21.6/",
-        urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.6.zip",  # 2022-09-13
-        ],
-    )
+
+    # Note that we don’t add an archive for the protocol buffers repository
+    # here, because µpb already depends on an unreleased version thereof.
     _toolchains(name = "phst_rules_elisp_toolchains")
 
 # buildifier: disable=unnamed-macro


### PR DESCRIPTION
This unblocks updating µpb, because newer versions depend on unreleased incompatible versions of Protocol Buffers.