### PR TITLE
Backport patch for Emacs 27.

### DIFF
--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -32,6 +32,7 @@ def rules_elisp_dependencies():
             "https://ftpmirror.gnu.org/emacs/emacs-27.1.tar.xz",
             "https://ftp.gnu.org/gnu/emacs/emacs-27.1.tar.xz",
         ],
+        patches = ["@phst_rules_elisp//:emacs-27.patch"],
     )
     maybe(
         http_archive,
@@ -43,6 +44,7 @@ def rules_elisp_dependencies():
             "https://ftpmirror.gnu.org/emacs/emacs-27.2.tar.xz",
             "https://ftp.gnu.org/gnu/emacs/emacs-27.2.tar.xz",
         ],
+        patches = ["@phst_rules_elisp//:emacs-27.patch"],
     )
     maybe(
         http_archive,

--- a/emacs-27.patch
+++ b/emacs-27.patch
@@ -1,0 +1,42 @@
+From 647a9353a35bb6f97a8494f1765400f8a34081ea Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 9 Mar 2021 11:22:59 -0800
+Subject: [PATCH] Port alternate signal stack to upcoming glibc 2.34
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* src/sysdep.c (sigsegv_stack): Increase size to 64 KiB and align
+it to max_align_t.  This copies from Gnulib’s c-stack.c, and works
+around a portability bug in draft glibc 2.34, which no longer
+defines SIGSTKSZ when _GNU_SOURCE is defined.
+
+(cherry picked from commit f97e07ea807cc6d38774a3888a15091b20645ac6)
+---
+ src/sysdep.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/sysdep.c b/src/sysdep.c
+index d100a5cb50..f0b97767ba 100644
+--- src/sysdep.c
++++ src/sysdep.c
+@@ -1818,7 +1818,15 @@ handle_arith_signal (int sig)
+ 
+ /* Alternate stack used by SIGSEGV handler below.  */
+ 
+-static unsigned char sigsegv_stack[SIGSTKSZ];
++/* Storage for the alternate signal stack.
++   64 KiB is not too large for Emacs, and is large enough
++   for all known platforms.  Smaller sizes may run into trouble.
++   For example, libsigsegv 2.6 through 2.8 have a bug where some
++   architectures use more than the Linux default of an 8 KiB alternate
++   stack when deciding if a fault was caused by stack overflow.  */
++static max_align_t sigsegv_stack[(64 * 1024
++				  + sizeof (max_align_t) - 1)
++				 / sizeof (max_align_t)];
+ 
+ 
+ /* Return true if SIGINFO indicates a stack overflow.  */
+-- 
+2.38.1.584.g0f3c55d4c2-goog
+


### PR DESCRIPTION
Without this, Emacs 27 no longer compiles under newer Debian/Ubuntu versions because SIGSTKSZ is no longer a constant.