### PR TITLE
Specify Python import path explicitly for Pytype.

### DIFF
--- a/check_python.py
+++ b/check_python.py
@@ -100,6 +100,7 @@ def main() -> None:
     if os.name == 'posix' and args.pytype:
         result = subprocess.run(
             [sys.executable, '-m', 'pytype',
+             '--pythonpath=' + os.pathsep.join(workspace.path),
              '--no-cache', '--'] + [str(file.relative_to(cwd))
                                     for file in sorted(workspace.srcs)],
             check=False, cwd=cwd, env=env,


### PR DESCRIPTION
Otherwise it tries to infer the path from the source files (ignoring the PYTHONPATH environment variable), which typically fails in our setup.