### PR TITLE
Don’t include the runfiles root in the Python imports path.

### DIFF
--- a/check_python.py
+++ b/check_python.py
@@ -49,7 +49,7 @@ class Workspace:
                 # https://github.com/bazelbuild/bazel/issues/10076.
                 (dirpath / '__init__.py').touch()
         self.srcs = frozenset(srcs)
-        self.path = [str(tempdir)] + [str(tempdir / d) for d in path]
+        self.path = [str(tempdir / d) for d in path]
         self.tempdir = tempdir
         self._output = out
 

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -26,7 +26,7 @@ import commonmark
 import commonmark.node
 import commonmark.render.renderer
 
-from phst_rules_elisp.docs import stardoc_output_pb2
+from docs import stardoc_output_pb2
 
 # The generated protocol buffer modules generate their members dynamically, so
 # Pylint can’t find them.

--- a/elisp/load.py
+++ b/elisp/load.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ on it in any way outside the rule implementation."""
 import pathlib
 from typing import Iterable, List
 
-from phst_rules_elisp.elisp import runfiles
+from elisp import runfiles
 
 def add_path(run_files: runfiles.Runfiles, args: List[str],
              load_path: Iterable[pathlib.PurePosixPath]) -> None:

--- a/elisp/load_test.py
+++ b/elisp/load_test.py
@@ -19,8 +19,8 @@ import pathlib
 import tempfile
 import unittest
 
-from phst_rules_elisp.elisp import load
-from phst_rules_elisp.elisp import runfiles
+from elisp import load
+from elisp import runfiles
 
 class AddPathTest(unittest.TestCase):
     """Unit tests for the load.add_path function."""

--- a/elisp/manifest_test.py
+++ b/elisp/manifest_test.py
@@ -20,7 +20,7 @@ import json
 import pathlib
 import unittest
 
-from phst_rules_elisp.elisp import manifest
+from elisp import manifest
 
 class ManifestTest(unittest.TestCase):
     """Unit tests for the manifest.add and manifest.write functions."""

--- a/elisp/run_binary.py
+++ b/elisp/run_binary.py
@@ -25,9 +25,9 @@ import subprocess
 import sys
 from typing import Iterable, Mapping, Optional, Sequence, Tuple
 
-from phst_rules_elisp.elisp import load
-from phst_rules_elisp.elisp import manifest
-from phst_rules_elisp.elisp import runfiles
+from elisp import load
+from elisp import manifest
+from elisp import runfiles
 
 def main() -> None:
     """Main function."""

--- a/elisp/run_emacs.py
+++ b/elisp/run_emacs.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 from typing import Iterable, Tuple
 
-from phst_rules_elisp.elisp import runfiles
+from elisp import runfiles
 
 def main() -> None:
     """Main function."""

--- a/elisp/run_test.py
+++ b/elisp/run_test.py
@@ -29,9 +29,9 @@ import time
 from typing import List, Tuple
 import urllib.parse
 
-from phst_rules_elisp.elisp import load
-from phst_rules_elisp.elisp import manifest
-from phst_rules_elisp.elisp import runfiles
+from elisp import load
+from elisp import manifest
+from elisp import runfiles
 
 def main() -> None:
     """Main function."""

--- a/elisp/runfiles.py
+++ b/elisp/runfiles.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021, 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import os
 import pathlib
 from typing import Mapping, Optional
 
-from bazel_tools.tools.python.runfiles import runfiles
+from tools.python.runfiles import runfiles
 
 class Runfiles:
     """Represents a set of Bazel runfiles."""

--- a/emacs/emacs_test.py
+++ b/emacs/emacs_test.py
@@ -19,7 +19,7 @@ import pathlib
 import subprocess
 import unittest
 
-from phst_rules_elisp.elisp import runfiles
+from elisp import runfiles
 
 class EmacsTest(unittest.TestCase):
     """Unit tests for the Emacs binary."""

--- a/examples/bin_test.py
+++ b/examples/bin_test.py
@@ -23,7 +23,7 @@ import subprocess
 import tempfile
 import unittest
 
-from phst_rules_elisp.elisp import runfiles
+from elisp import runfiles
 
 class BinaryTest(unittest.TestCase):
     """Example test showing how to work with elisp_binary rules."""

--- a/tests/wrap/wrap.py
+++ b/tests/wrap/wrap.py
@@ -23,7 +23,7 @@ import sys
 from typing import Any, Dict, List, Tuple
 import unittest
 
-from phst_rules_elisp.elisp import runfiles
+from elisp import runfiles
 
 def main() -> None:
     """Main function."""


### PR DESCRIPTION
With Bzlmod, workspace names under the runfiles root won’t be stable any more and therefore shouldn’t be used as part of module names.