### PR TITLE
Revert "Add support for outputting enumerator values in JSON"

### DIFF
--- a/docs/manual.org
+++ b/docs/manual.org
@@ -460,8 +460,6 @@ equals their default value; normally such fields are left out.  The
 ~:proto-names~ keyword argument determines the naming style for field names: by
 default, camel-case versions of the names are used, but if the keyword argument
 is non-~nil~, the names from the protocol buffer definition are used verbatim.
-If the ~:enum-numbers~ keyword argument is non-~nil~, the output will use
-numeric values for enumeration fields instead of enumerator names.
 #+END_defun
 
 You can print a human-readable representation of protocol buffer messages,

--- a/elisp/proto/module.c
+++ b/elisp/proto/module.c
@@ -272,8 +272,7 @@
   X(kCDeterministic, ":deterministic")                           \
   X(kCCompact, ":compact")                                       \
   X(kCEmitDefaults, ":emit-defaults")                            \
-  X(kCProtoNames, ":proto-names")                                \
-  X(kCEnumNumbers, ":enum-numbers")
+  X(kCProtoNames, ":proto-names")
 
 // clang-format off
 // Clang-Format get confused by this coding structure.
@@ -2901,9 +2900,8 @@ static emacs_value SerializeJson(emacs_env* env, ptrdiff_t nargs,
   int options = 0;
   const struct KeySpec specs[] = {
       {kCEmitDefaults, SetBit, upb_JsonEncode_EmitDefaults, &options},
-      {kCProtoNames, SetBit, upb_JsonEncode_UseProtoNames, &options},
-      {kCEnumNumbers, SetBit, upb_JsonEncode_FormatEnumsAsIntegers, &options}};
-  if (!ParseKeys(ctx, 3, specs, nargs - 1, args + 1)) return NULL;
+      {kCProtoNames, SetBit, upb_JsonEncode_UseProtoNames, &options}};
+  if (!ParseKeys(ctx, 2, specs, nargs - 1, args + 1)) return NULL;
   struct Allocator alloc = HeapAllocator();
   struct MutableString serialized =
       SerializeMessageJson(ctx, alloc, msg.type, msg.value, options);
@@ -3921,10 +3919,8 @@ int VISIBLE emacs_module_init(struct emacs_runtime* rt) {
         "Serialize a protocol buffer MESSAGE to its JSON representation.\n"
         "If EMIT-DEFAULTS is non-nil, emit default values.\n"
         "If PROTO-NAMES is non-nil, use protocol buffer (snake-case)\n"
-        "instead of JSON (camel-case) names.\n"
-        "If ENUM-NUMBERS is non-nil, use numeric values for enumeration\n"
-        "fields instead of enumerator names.\n\n"
-        "(fn message &key emit-defaults proto-names enum-numbers)",
+        "instead of JSON (camel-case) names.\n\n"
+        "(fn message &key emit-defaults proto-names)",
         kNoSideEffects, SerializeJson);
   Defun(ctx, "elisp/proto/message-mutable-p", 1, 1,
         "Return whether the protocol buffer MESSAGE is mutable.\n"

--- a/elisp/proto/proto-test.el
+++ b/elisp/proto/proto-test.el
@@ -881,16 +881,6 @@
                            (string-join (make-vector #x2000 "1") ",")
                            "]}")))))
 
-(ert-deftest elisp/proto/serialize-json/enum-numbers ()
-  (let ((message (elisp/proto/Test-new :enumeration elisp/proto/ENUM_BAR)))
-    (pcase-dolist (`(,enum-numbers ,expected)
-                   '((nil "{\"enumeration\":\"ENUM_BAR\"}")
-                     (t "{\"enumeration\":1}")))
-      (ert-info ((prin1-to-string enum-numbers) :prefix "enum-numbers: ")
-        (should (equal (elisp/proto/serialize-json message
-                                                   :enum-numbers enum-numbers)
-                       expected))))))
-
 (ert-deftest elisp/proto/any ()
   (let* ((message (elisp/proto/make-duration 123))
          (any (elisp/proto/pack-any message)))


### PR DESCRIPTION
This isn't supported in the release branch yet.

This reverts commit a7454084f8f2d591bc598ddef9fbc387e5e803ee.