### PR TITLE
Update to rules_python 0.16.1.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,9 +38,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_python",
-    sha256 = "bc4e59e17c7809a5b373ba359e2c974ed2386c58634819ac5a89c0813c15705c",
-    strip_prefix = "rules_python-0.15.1",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.15.1.tar.gz",
+    sha256 = "497ca47374f48c8b067d786b512ac10a276211810f4a580178ee9b9ad139323a",
+    strip_prefix = "rules_python-0.16.1",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.16.1.tar.gz",
 )
 
 register_toolchains("@//private:python_toolchain")


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_python/releases/tag/0.16.1.