### PR TITLE
Move Emacs BUILD rules into main workspace.

### DIFF
--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -25,7 +25,7 @@ def rules_elisp_dependencies():
     maybe(
         http_archive,
         name = "gnu_emacs_27.1",
-        build_file_content = _build_file(macos_arm = False),
+        build_file_content = _BUILD_FILE,
         sha256 = "4a4c128f915fc937d61edfc273c98106711b540c9be3cd5d2e2b9b5b2f172e41",
         strip_prefix = "emacs-27.1/",
         urls = [
@@ -37,7 +37,7 @@ def rules_elisp_dependencies():
     maybe(
         http_archive,
         name = "gnu_emacs_27.2",
-        build_file_content = _build_file(macos_arm = True),
+        build_file_content = _BUILD_FILE,
         sha256 = "b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9",
         strip_prefix = "emacs-27.2/",
         urls = [
@@ -49,7 +49,7 @@ def rules_elisp_dependencies():
     maybe(
         http_archive,
         name = "gnu_emacs_28.1",
-        build_file_content = _build_file(macos_arm = True),
+        build_file_content = _BUILD_FILE,
         sha256 = "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1",
         strip_prefix = "emacs-28.1/",
         urls = [
@@ -60,7 +60,7 @@ def rules_elisp_dependencies():
     maybe(
         http_archive,
         name = "gnu_emacs_28.2",
-        build_file_content = _build_file(macos_arm = True),
+        build_file_content = _BUILD_FILE,
         sha256 = "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488",
         strip_prefix = "emacs-28.2/",
         urls = [
@@ -131,37 +131,16 @@ _toolchains = repository_rule(
     implementation = _toolchains_impl,
 )
 
-def _build_file(*, macos_arm):
-    return _BUILD_TEMPLATE.format(
-        macos_arm = "" if macos_arm else '"@phst_rules_elisp//emacs:incompatible"',
-    )
-
-_BUILD_TEMPLATE = """
-load("@phst_rules_elisp//emacs:defs.bzl", "emacs_binary")
-
-emacs_binary(
-    name = "emacs",
+_BUILD_FILE = """
+filegroup(
+    name = "srcs",
     srcs = glob(["**"]),
-    builtin_features = "builtin_features.json",
-    module_header = "emacs-module.h",
-    readme = "README",
-    target_compatible_with = select({{
-        "@phst_rules_elisp//emacs:always_supported": [],
-        "@phst_rules_elisp//emacs:macos_arm": [{macos_arm}],
-        "//conditions:default": ["@phst_rules_elisp//emacs:incompatible"],
-    }}),
-    visibility = ["@phst_rules_elisp//emacs:__pkg__"],
-)
-
-cc_library(
-    name = "module_header",
-    srcs = ["emacs-module.h"],
     visibility = ["@phst_rules_elisp//emacs:__pkg__"],
 )
 
 filegroup(
-    name = "builtin_features",
-    srcs = ["builtin_features.json"],
+    name = "readme",
+    srcs = ["README"],
     visibility = ["@phst_rules_elisp//emacs:__pkg__"],
 )
 """

--- a/elisp/unix-toolchains.BUILD
+++ b/elisp/unix-toolchains.BUILD
@@ -15,12 +15,7 @@
 alias(
     name = "emacs_cc_toolchain",
     actual = "@bazel_tools//tools/cpp:current_cc_toolchain",
-    visibility = [
-        "@gnu_emacs_27.1//:__pkg__",
-        "@gnu_emacs_27.2//:__pkg__",
-        "@gnu_emacs_28.1//:__pkg__",
-        "@gnu_emacs_28.2//:__pkg__",
-    ],
+    visibility = ["@phst_rules_elisp//emacs:__pkg__"],
 )
 
 # Local Variables:

--- a/elisp/windows-toolchains.BUILD
+++ b/elisp/windows-toolchains.BUILD
@@ -18,12 +18,7 @@ cc_toolchain_suite(
         "x64_windows": "@local_config_cc//:cc-compiler-x64_windows_mingw",
         "x64_windows|mingw-gcc": "@local_config_cc//:cc-compiler-x64_windows_mingw",
     },
-    visibility = [
-        "@gnu_emacs_27.1//:__pkg__",
-        "@gnu_emacs_27.2//:__pkg__",
-        "@gnu_emacs_28.1//:__pkg__",
-        "@gnu_emacs_28.2//:__pkg__",
-    ],
+    visibility = ["@phst_rules_elisp//emacs:__pkg__"],
 )
 
 # Local Variables:

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -15,6 +15,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//private:defs.bzl", "cc_defaults")
+load(":defs.bzl", "emacs_binary")
 
 alias(
     name = "emacs",
@@ -33,39 +34,66 @@ py_test(
     deps = ["//elisp:runfiles"],
 )
 
-alias(
+cc_library(
     name = "module_header",
-    actual = "@gnu_emacs_28.2//:module_header",
+    srcs = ["emacs-module.h"],
+    includes = ["."],
     visibility = ["//visibility:public"],
 )
 
-alias(
+filegroup(
     name = "builtin_features",
-    actual = "@gnu_emacs_28.2//:builtin_features",
+    srcs = ["builtin_features.json"],
     visibility = ["//gazelle:__pkg__"],
 )
 
-alias(
+emacs_binary(
     name = "emacs_27.1",
-    actual = "@gnu_emacs_27.1//:emacs",
+    srcs = ["@gnu_emacs_27.1//:srcs"],
+    readme = "@gnu_emacs_27.1//:readme",
+    target_compatible_with = select({
+        ":always_supported": [],
+        ":macos_arm": [":incompatible"],
+        "//conditions:default": [":incompatible"],
+    }),
     visibility = ["//visibility:public"],
 )
 
-alias(
+emacs_binary(
     name = "emacs_27.2",
-    actual = "@gnu_emacs_27.2//:emacs",
+    srcs = ["@gnu_emacs_27.2//:srcs"],
+    readme = "@gnu_emacs_27.2//:readme",
+    target_compatible_with = select({
+        ":always_supported": [],
+        ":macos_arm": [],
+        "//conditions:default": [":incompatible"],
+    }),
     visibility = ["//visibility:public"],
 )
 
-alias(
+emacs_binary(
     name = "emacs_28.1",
-    actual = "@gnu_emacs_28.1//:emacs",
+    srcs = ["@gnu_emacs_28.1//:srcs"],
+    readme = "@gnu_emacs_28.1//:readme",
+    target_compatible_with = select({
+        ":always_supported": [],
+        ":macos_arm": [],
+        "//conditions:default": [":incompatible"],
+    }),
     visibility = ["//visibility:public"],
 )
 
-alias(
+emacs_binary(
     name = "emacs_28.2",
-    actual = "@gnu_emacs_28.2//:emacs",
+    srcs = ["@gnu_emacs_28.2//:srcs"],
+    builtin_features = "builtin_features.json",
+    module_header = "emacs-module.h",
+    readme = "@gnu_emacs_28.2//:readme",
+    target_compatible_with = select({
+        ":always_supported": [],
+        ":macos_arm": [],
+        "//conditions:default": [":incompatible"],
+    }),
     visibility = ["//visibility:public"],
 )
 
@@ -208,12 +236,6 @@ constraint_setting(name = "incompatible_setting")
 constraint_value(
     name = "incompatible",
     constraint_setting = ":incompatible_setting",
-    visibility = [
-        "@gnu_emacs_27.1//:__pkg__",
-        "@gnu_emacs_27.2//:__pkg__",
-        "@gnu_emacs_28.1//:__pkg__",
-        "@gnu_emacs_28.2//:__pkg__",
-    ],
 )
 
 cc_defaults(
@@ -232,10 +254,4 @@ cc_defaults(
         ],
         "//conditions:default": [],
     }),
-    visibility = [
-        "@gnu_emacs_27.1//:__pkg__",
-        "@gnu_emacs_27.2//:__pkg__",
-        "@gnu_emacs_28.1//:__pkg__",
-        "@gnu_emacs_28.2//:__pkg__",
-    ],
 )

--- a/emacs/emacs_test.py
+++ b/emacs/emacs_test.py
@@ -28,7 +28,8 @@ class EmacsTest(unittest.TestCase):
         """Tests that emacs --version works."""
         run_files = runfiles.Runfiles()
         emacs = run_files.resolve(pathlib.PurePosixPath(
-            'gnu_emacs_28.2/emacs' + ('.exe' if os.name == 'nt' else '')))
+            'phst_rules_elisp/emacs/emacs_28.2' +
+            ('.exe' if os.name == 'nt' else '')))
         env = dict(os.environ)
         env.update(run_files.environment())
         process = subprocess.run([str(emacs), '--version'], env=env,


### PR DESCRIPTION
This simplifies the repository rules quite a bit.