### PR TITLE
Use “rootpath” for finding binaries.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -193,6 +193,11 @@ cc_test(
     name = "binary_test",
     size = "small",
     srcs = ["binary_test.cc"],
+    args = [
+        # FIXME: Use rlocationpath once we drop support for Bazel older than
+        # version 5.4.0.
+        "$(rootpath //tests/wrap)",
+    ],
     copts = COPTS + CXXOPTS,
     data = [
         "binary.cc",
@@ -205,10 +210,13 @@ cc_test(
     local_defines = LAUNCHER_DEFINES,
     deps = [
         ":binary",
+        ":platform",
         ":process",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -28,6 +28,11 @@ py_test(
     size = "medium",
     timeout = "short",
     srcs = ["emacs_test.py"],
+    args = [
+        # FIXME: Use rlocationpath once we drop support for Bazel older than
+        # version 5.4.0.
+        "--emacs=$(rootpath :emacs)",
+    ],
     data = [":emacs"],
     python_version = "PY3",
     srcs_version = "PY3",

--- a/emacs/emacs_test.py
+++ b/emacs/emacs_test.py
@@ -14,9 +14,12 @@
 
 """Unit tests for the Emacs binary."""
 
+import argparse
 import os
 import pathlib
 import subprocess
+import sys
+from typing import Optional
 import unittest
 
 from elisp import runfiles
@@ -24,12 +27,12 @@ from elisp import runfiles
 class EmacsTest(unittest.TestCase):
     """Unit tests for the Emacs binary."""
 
+    emacs: Optional[pathlib.PurePosixPath] = None
+
     def test_version(self) -> None:
         """Tests that emacs --version works."""
         run_files = runfiles.Runfiles()
-        emacs = run_files.resolve(pathlib.PurePosixPath(
-            'phst_rules_elisp/emacs/emacs_28.2' +
-            ('.exe' if os.name == 'nt' else '')))
+        emacs = run_files.resolve('phst_rules_elisp' / self.emacs)
         env = dict(os.environ)
         env.update(run_files.environment())
         process = subprocess.run([str(emacs), '--version'], env=env,
@@ -37,5 +40,13 @@ class EmacsTest(unittest.TestCase):
         self.assertEqual(process.returncode, 0)
 
 
+def _main() -> None:
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument('--emacs', type=pathlib.PurePosixPath, required=True)
+    args = parser.parse_args()
+    EmacsTest.emacs = args.emacs
+    unittest.main(argv=sys.argv[:1])
+
+
 if __name__ == '__main__':
-    unittest.main()
+    _main()

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -27,6 +27,11 @@ go_test(
     size = "medium",
     timeout = "short",
     srcs = ["ert_test.go"],
+    args = [
+        # FIXME: Use rlocationpath once we drop support for Bazel older than
+        # version 5.4.0.
+        "--binary=$(rootpath :test_test)",
+    ],
     data = [
         ":test_test",
         "@junit_xsd//:file",

--- a/tests/ert_test.go
+++ b/tests/ert_test.go
@@ -16,13 +16,14 @@ package runner_test
 
 import (
 	"encoding/xml"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -31,6 +32,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
+
+var binary = flag.String("binary", "", "location of the binary file relative to the runfiles root")
 
 func Test(t *testing.T) {
 	source, err := runfiles.Rlocation("phst_rules_elisp/tests/test.el")
@@ -41,11 +44,7 @@ func Test(t *testing.T) {
 	// filenames in the coverage report are correct.
 	workspace := filepath.Dir(filepath.Dir(source))
 	t.Logf("running test in workspace directory %s", workspace)
-	bin := "phst_rules_elisp/tests/test_test"
-	if runtime.GOOS == "windows" {
-		bin += ".exe"
-	}
-	bin, err = runfiles.Rlocation(bin)
+	bin, err := runfiles.Rlocation(path.Join("phst_rules_elisp", *binary))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This saves us the hassle of appending the .exe suffix manually.