### PR TITLE
Revert "Don’t register hermetic Python toolchains."

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,7 +49,6 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 python_register_toolchains(
     name = "hermetic_python",
     python_version = "3.10",
-    register_toolchains = False,
 )
 
 load("@rules_python//python:pip.bzl", "pip_parse")


### PR DESCRIPTION
Turns out that this is necessary after all.

This reverts commit 9c959eb57ff565e03d371c98dfdd47b8bcb3a8d4.