### PR TITLE
Remove unnecessary config_setting rules.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,9 +42,9 @@ compile_pip_requirements(
 alias(
     name = "requirements_txt",
     actual = select({
-        "//constraints:linux": "linux-requirements.txt",
-        "//constraints:macos": "macos-requirements.txt",
-        "//constraints:windows": "windows-requirements.txt",
+        "@platforms//os:linux": "linux-requirements.txt",
+        "@platforms//os:macos": "macos-requirements.txt",
+        "@platforms//os:windows": "windows-requirements.txt",
     }),
 )
 

--- a/constraints/BUILD
+++ b/constraints/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,21 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-config_setting(
-    name = "linux",
-    constraint_values = ["@platforms//os:linux"],
-)
-
-config_setting(
-    name = "macos",
-    constraint_values = ["@platforms//os:macos"],
-)
-
-config_setting(
-    name = "windows",
-    constraint_values = ["@platforms//os:windows"],
-)
 
 config_setting(
     name = "msvc-cl",

--- a/elisp/proto/BUILD
+++ b/elisp/proto/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022 Google LLC
+# Copyright 2020, 2021, 2022, 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -117,9 +117,9 @@ elisp_proto_library(
 elisp_library(
     name = "module",
     srcs = select({
-        "//constraints:linux": ["module.so"],
-        "//constraints:macos": ["module.so"],
-        "//constraints:windows": ["module.dll"],
+        "@platforms//os:linux": ["module.so"],
+        "@platforms//os:macos": ["module.so"],
+        "@platforms//os:windows": ["module.dll"],
     }),
 )
 
@@ -135,12 +135,12 @@ cc_binary(
     }),
     linkopts = select({
         # Export only symbols that make up the module interface.
-        "//constraints:linux": [
+        "@platforms//os:linux": [
             "-Wl,--version-script=$(execpath :module.lds)",
             "-Wl,--no-undefined",
         ],
-        "//constraints:windows": [],  # uses ‘win_def_file’
-        "//constraints:macos": [
+        "@platforms//os:windows": [],  # uses ‘win_def_file’
+        "@platforms//os:macos": [
             "-Wl,-exported_symbol,_emacs_module_init",
             "-Wl,-exported_symbol,_plugin_is_GPL_compatible",
             "-Wl,-undefined,error",

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -251,7 +251,7 @@ cc_defaults(
         "NO_SHLWAPI_ISOS",  # Work around https://bugs.gnu.org/48303
     ],
     linkopts = select({
-        "//constraints:macos": [
+        "@platforms//os:macos": [
             # Override the toolchain’s “-undefined dynamic” option so that the
             # configure script doesn’t incorrectly detect absent functions as
             # present.

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -41,9 +41,9 @@ elisp_library(
         "lib-2-a.el",
         "lib-2-b.el",
     ] + select({
-        "//constraints:linux": ["module.so"],
-        "//constraints:macos": ["module.so"],
-        "//constraints:windows": ["module.dll"],
+        "@platforms//os:linux": ["module.so"],
+        "@platforms//os:macos": ["module.so"],
+        "@platforms//os:windows": ["module.dll"],
     }),
     fatal_warnings = False,
     load_path = ["."],

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -373,9 +373,9 @@ CONLYOPTS = select({
 })
 
 DEFINES = ["_GNU_SOURCE"] + select({
-    Label("//constraints:linux"): [],
-    Label("//constraints:macos"): [],
-    Label("//constraints:windows"): [
+    Label("@platforms//os:linux"): [],
+    Label("@platforms//os:macos"): [],
+    Label("@platforms//os:windows"): [
         "_UNICODE",
         "UNICODE",
         "STRICT",


### PR DESCRIPTION
All supported versions of Bazel now support selecting on constraint_value rules directly.