### PR TITLE
Don’t test each point release of Bazel individually.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        bazel: [5.1.0, 5.1.1, 5.2.0, 5.3.0, 5.3.1, 5.3.2, 5.4.0, 6.0.0,
+        bazel: [5.1.0, 5.1.1, 5.2.0, 5.3.2, 5.4.0, 6.0.0,
                 latest, rolling]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
Otherwise there are just too many elements in the test matrix.