### PR TITLE
Improve compatibility with Emacs 29.

### DIFF
--- a/elisp/ert/runner.el
+++ b/elisp/ert/runner.el
@@ -821,7 +821,7 @@ TABLE."
   "Insert a coverage report into the current buffer.
 BUFFER must be a different buffer visiting an Emacs Lisp source
 file that has been instrumented with Edebug."
-  (cl-check-type buffer buffer-live)
+  (cl-check-type buffer (and buffer (satisfies buffer-live-p)))
   (let ((file-name (elisp/ert/sanitize--string
                     (elisp/ert/file--display-name (buffer-file-name buffer))))
         (functions ())
@@ -1083,7 +1083,8 @@ exact copies as equal."
                      (let ((new (cl-etypecase obj
                                   (symbol (elisp/ert/check--xml-name obj))
                                   (string (elisp/ert/sanitize--xml-string obj))
-                                  (proper-list (mapcar #'walk obj))
+                                  ((and list (satisfies proper-list-p))
+                                   (mapcar #'walk obj))
                                   (cons
                                    (cons (walk (car obj)) (walk (cdr obj)))))))
                        (puthash obj new map)

--- a/elisp/proto/generate.el
+++ b/elisp/proto/generate.el
@@ -1,6 +1,6 @@
 ;;; generate.el --- generate protocol buffer bindings -*- lexical-binding: t; -*-
 
-;; Copyright 2021, 2022 Google LLC
+;; Copyright 2021, 2022, 2023 Google LLC
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -31,11 +31,12 @@
 
 (require 'elisp/proto/proto)
 
-(defun elisp/proto/simple-string-p (o)
-  "Return whether O is a string that’s unlikely to cause trouble."
-  (declare (side-effect-free t))
-  (and (stringp o)
-       (string-match-p (rx bos (+ (any blank alnum ?_ ?- ?. ?/ ?: ?@)) eos) o)))
+(cl-deftype elisp/proto/simple-string ()
+  '(and string
+        (satisfies (lambda (string)
+                     (string-match-p
+                      (rx bos (+ (any blank alnum ?_ ?- ?. ?/ ?: ?@)) eos)
+                      string)))))
 
 (defun elisp/proto/generate-message (full-name fields)
   "Generate code for the protocol buffer message type FULL-NAME.


### PR DESCRIPTION
With commit 5ee4209f307fdf8cde9775539c9596d29edccd6d, Emacs no longer treats ‘proper-list’ and ‘buffer-live’ as types, so use equivalent predicates instead.