### PR TITLE
Use “rlocationpath” for finding binaries.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -196,11 +196,7 @@ cc_test(
     name = "binary_test",
     size = "small",
     srcs = ["binary_test.cc"],
-    args = [
-        # FIXME: Use rlocationpath once we drop support for Bazel older than
-        # version 5.4.0.
-        "$(rootpath //tests/wrap)",
-    ],
+    args = ["$(rlocationpath //tests/wrap)"],
     copts = COPTS + CXXOPTS,
     data = [
         "binary.cc",

--- a/elisp/binary_test.cc
+++ b/elisp/binary_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Google LLC
+// Copyright 2020, 2021, 2022, 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ TEST(Executor, RunBinaryWrap) {
       runfiles->Resolve("phst_rules_elisp/elisp/binary.cc");
   ASSERT_TRUE(input_file.ok()) << input_file.status();
   const std::vector<NativeString> args = {
-      PHST_RULES_ELISP_NATIVE_LITERAL("--wrapper=phst_rules_elisp/") + wrapper,
+      PHST_RULES_ELISP_NATIVE_LITERAL("--wrapper=") + wrapper,
       PHST_RULES_ELISP_NATIVE_LITERAL("--mode=wrap"),
       PHST_RULES_ELISP_NATIVE_LITERAL("--rule-tag=local"),
       PHST_RULES_ELISP_NATIVE_LITERAL("--rule-tag=mytag"),

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -35,11 +35,7 @@ py_test(
     size = "medium",
     timeout = "short",
     srcs = ["emacs_test.py"],
-    args = [
-        # FIXME: Use rlocationpath once we drop support for Bazel older than
-        # version 5.4.0.
-        "--emacs=$(rootpath :emacs)",
-    ],
+    args = ["--emacs=$(rlocationpath :emacs)"],
     data = [":emacs"],
     python_version = "PY3",
     srcs_version = "PY3",

--- a/emacs/emacs_test.py
+++ b/emacs/emacs_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022 Google LLC
+# Copyright 2020, 2021, 2022, 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ class EmacsTest(unittest.TestCase):
     def test_version(self) -> None:
         """Tests that emacs --version works."""
         run_files = runfiles.Runfiles()
-        emacs = run_files.resolve('phst_rules_elisp' / self.emacs)
+        emacs = run_files.resolve(self.emacs)
         env = dict(os.environ)
         env.update(run_files.environment())
         process = subprocess.run([str(emacs), '--version'], env=env,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -34,11 +34,7 @@ go_test(
     size = "medium",
     timeout = "short",
     srcs = ["ert_test.go"],
-    args = [
-        # FIXME: Use rlocationpath once we drop support for Bazel older than
-        # version 5.4.0.
-        "--binary=$(rootpath :test_test)",
-    ],
+    args = ["--binary=$(rlocationpath :test_test)"],
     data = [
         ":test_test",
         "@junit_xsd//:file",

--- a/tests/ert_test.go
+++ b/tests/ert_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -46,7 +45,7 @@ func Test(t *testing.T) {
 	// filenames in the coverage report are correct.
 	workspace := filepath.Dir(filepath.Dir(source))
 	t.Logf("running test in workspace directory %s", workspace)
-	bin, err := runfiles.Rlocation(path.Join("phst_rules_elisp", *binary))
+	bin, err := runfiles.Rlocation(*binary)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This saves us the hassle of appending the .exe suffix manually.