### PR TITLE
Use local defines for runner binaries.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -15,7 +15,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//private:defs.bzl", "COPTS", "CXXOPTS", "DEFINES", "FEATURES", "bootstrap", "cc_defaults")
+load("//private:defs.bzl", "COPTS", "CXXOPTS", "DEFINES", "FEATURES", "bootstrap", "cc_defaults", "executable_only")
 load(":defs.bzl", "elisp_binary", "elisp_toolchain")
 
 package(
@@ -151,11 +151,15 @@ cc_library(
     srcs = ["emacs.cc"],
     hdrs = ["emacs.h"],
     copts = COPTS + CXXOPTS,
-    data = [":run_emacs"],
+    data = [":run_emacs_stripped"],
     features = FEATURES,
     linkopts = LINKOPTS,
     linkstatic = True,
-    local_defines = DEFINES,
+    local_defines = DEFINES + [
+        # See https://github.com/bazelbuild/bazel/issues/8380 why we need to add
+        # additional quoting.
+        """PHST_RULES_ELISP_RUN_EMACS='R"*($(rlocationpath :run_emacs_stripped))*"'""",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":platform",
@@ -176,16 +180,25 @@ py_binary(
     deps = [":runfiles"],
 )
 
+executable_only(
+    name = "run_emacs_stripped",
+    src = ":run_emacs",
+)
+
 cc_library(
     name = "binary",
     srcs = ["binary.cc"],
     hdrs = ["binary.h"],
     copts = COPTS + CXXOPTS,
-    data = [":run_binary"],
+    data = [":run_binary_stripped"],
     features = FEATURES,
     linkopts = LINKOPTS,
     linkstatic = True,
-    local_defines = DEFINES,
+    local_defines = DEFINES + [
+        # See https://github.com/bazelbuild/bazel/issues/8380 why we need to add
+        # additional quoting.
+        """PHST_RULES_ELISP_RUN_BINARY='R"*($(rlocationpath :run_binary_stripped))*"'""",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":platform",
@@ -239,17 +252,26 @@ py_binary(
     ],
 )
 
+executable_only(
+    name = "run_binary_stripped",
+    src = ":run_binary",
+)
+
 cc_library(
     name = "test",
     testonly = 1,
     srcs = ["test.cc"],
     hdrs = ["test.h"],
     copts = COPTS + CXXOPTS,
-    data = [":run_test"],
+    data = [":run_test_stripped"],
     features = FEATURES,
     linkopts = LINKOPTS,
     linkstatic = True,
-    local_defines = DEFINES,
+    local_defines = DEFINES + [
+        # See https://github.com/bazelbuild/bazel/issues/8380 why we need to add
+        # additional quoting.
+        """PHST_RULES_ELISP_RUN_TEST='R"*($(rlocationpath :run_test_stripped))*"'""",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":platform",
@@ -274,6 +296,12 @@ py_binary(
         ":manifest",
         ":runfiles",
     ],
+)
+
+executable_only(
+    name = "run_test_stripped",
+    testonly = True,
+    src = ":run_test",
 )
 
 py_library(

--- a/elisp/binary.cc
+++ b/elisp/binary.cc
@@ -46,7 +46,7 @@ static absl::StatusOr<int> RunBinaryImpl(
   const absl::StatusOr<Runfiles> runfiles =
       Runfiles::Create(BAZEL_CURRENT_REPOSITORY, argv0);
   if (!runfiles.ok()) return runfiles.status();
-  return Run("phst_rules_elisp/elisp/run_binary", args, *runfiles);
+  return Run(PHST_RULES_ELISP_RUN_BINARY, args, *runfiles);
 }
 
 int RunBinary(const NativeString& argv0,

--- a/elisp/emacs.cc
+++ b/elisp/emacs.cc
@@ -46,7 +46,7 @@ static absl::StatusOr<int> RunEmacsImpl(const NativeString& argv0,
   const absl::StatusOr<Runfiles> runfiles =
       Runfiles::Create(BAZEL_CURRENT_REPOSITORY, argv0);
   if (!runfiles.ok()) return runfiles.status();
-  return Run("phst_rules_elisp/elisp/run_emacs", args, *runfiles);
+  return Run(PHST_RULES_ELISP_RUN_EMACS, args, *runfiles);
 }
 
 int RunEmacs(const NativeString& argv0, const std::vector<NativeString>& args) {

--- a/elisp/test.cc
+++ b/elisp/test.cc
@@ -45,7 +45,7 @@ static absl::StatusOr<int> RunTestImpl(const std::vector<NativeString>& args) {
   const absl::StatusOr<Runfiles> runfiles =
       Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY);
   if (!runfiles.ok()) return runfiles.status();
-  return Run("phst_rules_elisp/elisp/run_test", args, *runfiles);
+  return Run(PHST_RULES_ELISP_RUN_TEST, args, *runfiles);
 }
 
 int RunTest(const std::vector<NativeString>& args) {

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -458,6 +458,30 @@ bootstrap = rule(
     toolchains = [Label("//elisp:toolchain_type")],
 )
 
+def _executable_only_impl(ctx):
+    info = ctx.attr.src[DefaultInfo]
+    files_to_run = info.files_to_run
+    if not files_to_run:
+        fail("missing files_to_run")
+    executable = info.files_to_run.executable
+    if not executable:
+        fail("missing executable")
+    return DefaultInfo(
+        files = depset([executable]),
+        runfiles = info.default_runfiles,
+    )
+
+executable_only = rule(
+    implementation = _executable_only_impl,
+    attrs = {"src": attr.label(mandatory = True)},
+    doc = """Strip non-executable output files from `src`.
+
+Use this rule to wrap a `py_binary` target for use with `$(rlocationpath …)`
+etc.  This is necessary because `py_binary` also returns the main source file as
+additional file to build.
+""",
+)
+
 def _merged_manual_impl(ctx):
     tool_inputs, input_manifests = ctx.resolve_tools(tools = [ctx.attr._generate])
     orgs = []


### PR DESCRIPTION
This removes a dependency on the workspace name.