### PR TITLE
Add runfile name handler for abbreviate-file-name.

### DIFF
--- a/elisp/runfiles/runfiles-test.el
+++ b/elisp/runfiles/runfiles-test.el
@@ -114,6 +114,9 @@ context."
                    "runfiles/test.txt"))
     (should (equal (file-truename "/bazel-runfile:phst_rules_elisp/elisp/")
                    "/bazel-runfile:phst_rules_elisp/elisp/"))
+    (should (equal (abbreviate-file-name
+                    "/bazel-runfile:phst_rules_elisp/elisp/runfiles/test.txt")
+                   "/bazel-runfile:phst_rules_elisp/elisp/runfiles/test.txt"))
     (let ((load-path '("/bazel-runfile:phst_rules_elisp")))
       (require 'elisp/runfiles/test-lib))))
 

--- a/elisp/runfiles/runfiles.el
+++ b/elisp/runfiles/runfiles.el
@@ -199,6 +199,14 @@ ARGS are the arguments to the operation."
      ;; Attempt to handle everything else in a generic way.
      (t (elisp/runfiles/handle--generic operation args)))))
 
+(defun elisp/runfiles/handle--abbreviate-file-name (filename)
+  "Implementation of ‘abbreviate-file-name’ for Bazel runfiles.
+See Info node ‘(elisp) Directory Names’ for the meaning of
+FILENAME."
+  ;; We don’t support abbreviated file names, so we return the file name
+  ;; unchanged.
+  filename)
+
 (defun elisp/runfiles/handle--directory-files
     (directory full-name match-regexp nosort)
   "Implementation of ‘directory-files’ for Bazel runfiles.


### PR DESCRIPTION
This isn’t used in Emacs 28, but will be in Emacs 29.