### PR TITLE
Ignore external example when building the main workspace.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# examples/ext contains another Bazel workspace, it should be ignored when
+# building the main workspace.
+examples/ext


### PR DESCRIPTION
This should avoid the “infinite symlink expansion” error.