### PR TITLE
Allow tilde character in filenames.

### DIFF
--- a/elisp/proto/generate.el
+++ b/elisp/proto/generate.el
@@ -35,7 +35,7 @@
   '(and string
         (satisfies (lambda (string)
                      (string-match-p
-                      (rx bos (+ (any blank alnum ?_ ?- ?. ?/ ?: ?@)) eos)
+                      (rx bos (+ (any blank alnum ?_ ?- ?. ?/ ?: ?@ ?~)) eos)
                       string)))))
 
 (defun elisp/proto/generate-message (full-name fields)

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -117,7 +117,7 @@ def check_relative_filename(filename):
     if not (filename == "." or filename[0].isalpha() or filename.startswith("_")):
         fail("filename {} has to start with a letter or underscore".format(filename))
     for char in filename.elems():
-        if not (char.isalnum() or char in "-_./+$@%=,"):
+        if not (char.isalnum() or char in "-_./+$@%=,~"):
             fail("invalid character {} in filename {}".format(char, filename))
     return filename
 


### PR DESCRIPTION
With Bzlmod, Bazel generates workspace names that contain tilde characters, so we need to allow them if we want to support Bzlmod.