### PR TITLE
Factor out dependencies that are not available as modules.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,15 +116,9 @@ load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
 
 googletest_deps()
 
-http_archive(
-    name = "junit_xsd",
-    build_file = "@//:junit_xsd.BUILD",
-    sha256 = "ba809d0fedfb392cc604ad38aff7db7d750b77eaf5fed977a51360fa4a6dffdf",
-    strip_prefix = "JUnit-Schema-1.0.0/",
-    urls = [
-        "https://github.com/windyroad/JUnit-Schema/archive/refs/tags/1.0.0.tar.gz",  # 2022-04-09
-    ],
-)
+load("//private:repositories.bzl", "non_module_dev_deps")
+
+non_module_dev_deps()
 
 http_archive(
     name = "io_bazel_rules_go",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -94,7 +94,10 @@ stardoc(
     out = "repositories.bin",
     format = "proto",
     input = "//elisp:repositories.bzl",
-    deps = ["//elisp:builtin_bzl"],
+    deps = [
+        "//elisp:builtin_bzl",
+        "//private:repositories_bzl",
+    ],
 )
 
 py_binary(

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -110,6 +110,7 @@ bzl_library(
 bzl_library(
     name = "repositories_bzl",
     srcs = ["repositories.bzl"],
+    deps = ["//private:repositories_bzl"],
 )
 
 bzl_library(

--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -16,45 +16,13 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//private:repositories.bzl", "non_module_deps")
 
 def rules_elisp_dependencies():
     """Installs necessary dependencies for Emacs Lisp rules.
 
     Call this function in your `WORKSPACE` file.
     """
-    maybe(
-        http_archive,
-        name = "gnu_emacs_28.1",
-        build_file = Label("//:emacs.BUILD"),
-        sha256 = "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1",
-        strip_prefix = "emacs-28.1/",
-        urls = [
-            "https://ftpmirror.gnu.org/emacs/emacs-28.1.tar.xz",
-            "https://ftp.gnu.org/gnu/emacs/emacs-28.1.tar.xz",
-        ],
-    )
-    maybe(
-        http_archive,
-        name = "gnu_emacs_28.2",
-        build_file = Label("//:emacs.BUILD"),
-        sha256 = "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488",
-        strip_prefix = "emacs-28.2/",
-        urls = [
-            "https://ftpmirror.gnu.org/emacs/emacs-28.2.tar.xz",
-            "https://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.xz",
-        ],
-    )
-    maybe(
-        http_archive,
-        name = "gnu_emacs_29.1",
-        build_file = Label("//:emacs.BUILD"),
-        sha256 = "d2f881a5cc231e2f5a03e86f4584b0438f83edd7598a09d24a21bd8d003e2e01",
-        strip_prefix = "emacs-29.1/",
-        urls = [
-            "https://ftpmirror.gnu.org/emacs/emacs-29.1.tar.xz",
-            "https://ftp.gnu.org/gnu/emacs/emacs-29.1.tar.xz",
-        ],
-    )
     maybe(
         http_archive,
         name = "platforms",
@@ -117,18 +85,9 @@ def rules_elisp_dependencies():
             "https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.zip",  # 2022-09-23
         ],
     )
-    _toolchains(name = "phst_rules_elisp_toolchains")
+    non_module_deps()
 
 # buildifier: disable=unnamed-macro
 def rules_elisp_toolchains():
     """Registers the default toolchains for Emacs Lisp."""
     native.register_toolchains("@phst_rules_elisp//elisp:hermetic_toolchain")
-
-def _toolchains_impl(repository_ctx):
-    windows = repository_ctx.os.name.startswith("windows")
-    target = Label("//elisp:windows-toolchains.BUILD" if windows else "//elisp:unix-toolchains.BUILD")
-    repository_ctx.symlink(target, "BUILD")
-
-_toolchains = repository_rule(
-    implementation = _toolchains_impl,
-)

--- a/private/BUILD
+++ b/private/BUILD
@@ -35,6 +35,15 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "repositories_bzl",
+    srcs = ["repositories.bzl"],
+    visibility = [
+        "//docs:__pkg__",
+        "//elisp:__pkg__",
+    ],
+)
+
 config_setting(
     name = "msvc-cl",
     flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},

--- a/private/repositories.bzl
+++ b/private/repositories.bzl
@@ -56,6 +56,19 @@ def non_module_deps():
     )
     _toolchains(name = "phst_rules_elisp_toolchains")
 
+def non_module_dev_deps():
+    """Installs development dependencies that are not available as modules."""
+    maybe(
+        http_archive,
+        name = "junit_xsd",
+        build_file = "@//:junit_xsd.BUILD",
+        sha256 = "ba809d0fedfb392cc604ad38aff7db7d750b77eaf5fed977a51360fa4a6dffdf",
+        strip_prefix = "JUnit-Schema-1.0.0/",
+        urls = [
+            "https://github.com/windyroad/JUnit-Schema/archive/refs/tags/1.0.0.tar.gz",  # 2022-04-09
+        ],
+    )
+
 def _toolchains_impl(repository_ctx):
     windows = repository_ctx.os.name.startswith("windows")
     target = Label("//elisp:windows-toolchains.BUILD" if windows else "//elisp:unix-toolchains.BUILD")

--- a/private/repositories.bzl
+++ b/private/repositories.bzl
@@ -1,0 +1,66 @@
+# Copyright 2020, 2021, 2022, 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal-only workspace functions.
+
+These definitions are internal and subject to change without notice."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def non_module_deps():
+    """Installs dependencies that are not available as modules."""
+    maybe(
+        http_archive,
+        name = "gnu_emacs_28.1",
+        build_file = Label("//:emacs.BUILD"),
+        sha256 = "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1",
+        strip_prefix = "emacs-28.1/",
+        urls = [
+            "https://ftpmirror.gnu.org/emacs/emacs-28.1.tar.xz",
+            "https://ftp.gnu.org/gnu/emacs/emacs-28.1.tar.xz",
+        ],
+    )
+    maybe(
+        http_archive,
+        name = "gnu_emacs_28.2",
+        build_file = Label("//:emacs.BUILD"),
+        sha256 = "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488",
+        strip_prefix = "emacs-28.2/",
+        urls = [
+            "https://ftpmirror.gnu.org/emacs/emacs-28.2.tar.xz",
+            "https://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.xz",
+        ],
+    )
+    maybe(
+        http_archive,
+        name = "gnu_emacs_29.1",
+        build_file = Label("//:emacs.BUILD"),
+        sha256 = "d2f881a5cc231e2f5a03e86f4584b0438f83edd7598a09d24a21bd8d003e2e01",
+        strip_prefix = "emacs-29.1/",
+        urls = [
+            "https://ftpmirror.gnu.org/emacs/emacs-29.1.tar.xz",
+            "https://ftp.gnu.org/gnu/emacs/emacs-29.1.tar.xz",
+        ],
+    )
+    _toolchains(name = "phst_rules_elisp_toolchains")
+
+def _toolchains_impl(repository_ctx):
+    windows = repository_ctx.os.name.startswith("windows")
+    target = Label("//elisp:windows-toolchains.BUILD" if windows else "//elisp:unix-toolchains.BUILD")
+    repository_ctx.symlink(target, "BUILD")
+
+_toolchains = repository_rule(
+    implementation = _toolchains_impl,
+)


### PR DESCRIPTION
That will allow us to reuse the newly-added function when enabling Bzlmod.