### PR TITLE
Remove orig_env variables.

### DIFF
--- a/elisp/run_binary.py
+++ b/elisp/run_binary.py
@@ -50,11 +50,11 @@ def main() -> None:
     parser.add_argument('--output-arg', action='append', type=int, default=[])
     parser.add_argument('argv', nargs='+')
     opts = parser.parse_args()
-    orig_env = dict(os.environ)
+    env: dict[str, str] = dict(os.environ)
     # We don’t want the Python launcher to change the current working directory,
     # otherwise relative filenames will be all messed up.  See
     # https://github.com/bazelbuild/bazel/issues/7190.
-    orig_env.pop('RUN_UNDER_RUNFILES', None)
+    env.pop('RUN_UNDER_RUNFILES', None)
     run_files = runfiles.Runfiles(dict(opts.runfiles_env))
     emacs = run_files.resolve(opts.wrapper)
     args: list[str] = [str(emacs)]
@@ -67,12 +67,11 @@ def main() -> None:
             abs_name = run_files.resolve(file)
             args.append('--load=' + str(abs_name))
         if manifest_file:
-            runfiles_dir = _runfiles_dir(orig_env)
+            runfiles_dir = _runfiles_dir(env)
             input_files = _arg_files(opts.argv, runfiles_dir, opts.input_arg)
             output_files = _arg_files(opts.argv, runfiles_dir, opts.output_arg)
             manifest.write(opts, input_files, output_files, manifest_file)
         args.extend(opts.argv[1:])
-        env = dict(orig_env)
         env.update(opts.env)
         env.update(run_files.environment())
         try:

--- a/elisp/run_test.py
+++ b/elisp/run_test.py
@@ -57,11 +57,11 @@ def main() -> None:
     # explicit request.
     logging.basicConfig(level=logging.INFO,
                         format='%(asctime)s %(levelname)s %(name)s %(message)s')
-    orig_env = dict(os.environ)
+    env: dict[str, str] = dict(os.environ)
     # We don’t want the Python launcher to change the current working directory,
     # otherwise relative filenames will be all messed up.  See
     # https://github.com/bazelbuild/bazel/issues/7190.
-    orig_env.pop('RUN_UNDER_RUNFILES', None)
+    env.pop('RUN_UNDER_RUNFILES', None)
     run_files = runfiles.Runfiles(dict(opts.runfiles_env))
     emacs = run_files.resolve(opts.wrapper)
     args: list[str] = [str(emacs)]
@@ -84,7 +84,6 @@ def main() -> None:
             args += ['--skip-tag', _quote(tag)]
         args.append('--funcall=elisp/ert/run-batch-and-exit')
         args.extend(opts.argv[1:])
-        env = dict(orig_env)
         env.update(opts.env)
         env.update(run_files.environment())
         if manifest_file:
@@ -111,7 +110,7 @@ def main() -> None:
             # process, see https://github.com/bazelbuild/bazel/issues/12684.  We
             # work around this by creating a new process group and sending
             # CTRL + BREAK slightly before Bazel kills us.
-            timeout_str = orig_env.get('TEST_TIMEOUT') or None
+            timeout_str = env.get('TEST_TIMEOUT') or None
             if timeout_str:
                 # Lower the timeout to account for infrastructure overhead.
                 timeout_secs = int(timeout_str) - 2


### PR DESCRIPTION
The difference between the original and the modified environment shouldn’t matter in practice.