### PR TITLE
Revert "Temporarily skip rolling release tests."

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -29,9 +29,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        # FIXME: add “rolling” once
-        # https://github.com/bazelbuild/bazel/issues/18131 is fixed.
-        bazel: [5.4.0, 6.0.0, 6.1.2, 6.2.1, 6.3.1, latest]
+        bazel: [5.4.0, 6.0.0, 6.1.2, 6.2.1, 6.3.1, latest, rolling]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
This reverts commit eb4ebfecc31c205ff8a1525e3849f7b60477ab52.