### PR TITLE
Mark Go extensions as development-only dependency.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,7 +66,7 @@ pip.parse(
 use_repo(pip, pip_deps = "pip")
 
 # Go-specific dependencies
-go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
 go_deps.module(
     path = "github.com/bazelbuild/buildtools",
     sum = "h1:skvX7icFzwe3yKdg2wZALO+aLAYs13Qua1v2iZPo2HE=",


### PR DESCRIPTION
The “dev_dependency” setting must match the one from the “bazel_gazelle” repository.