### PR TITLE
Remove grep_includes

### DIFF
--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -480,12 +480,6 @@ elisp_binary = rule(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
             providers = [cc_common.CcToolchainInfo],
         ),
-        _grep_includes = attr.label(
-            allow_single_file = True,
-            executable = True,
-            cfg = "exec",
-            default = Label("@bazel_tools//tools/cpp:grep-includes"),
-        ),
         _binary_libs = attr.label_list(
             default = [Label("//elisp:binary")],
             providers = [CcInfo],
@@ -556,12 +550,6 @@ elisp_test = rule(
         _cc_toolchain = attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
             providers = [cc_common.CcToolchainInfo],
-        ),
-        _grep_includes = attr.label(
-            allow_single_file = True,
-            executable = True,
-            cfg = "exec",
-            default = Label("@bazel_tools//tools/cpp:grep-includes"),
         ),
         _test_libs = attr.label_list(
             default = [Label("//elisp:test")],

--- a/emacs/defs.bzl
+++ b/emacs/defs.bzl
@@ -102,12 +102,6 @@ This is used by Gazelle.""",
             default = Label("@phst_rules_elisp_toolchains//:emacs_cc_toolchain"),
             providers = [cc_common.CcToolchainInfo],
         ),
-        "_grep_includes": attr.label(
-            allow_single_file = True,
-            executable = True,
-            cfg = "exec",
-            default = Label("@bazel_tools//tools/cpp:grep-includes"),
-        ),
         "_emacs_libs": attr.label_list(
             default = [Label("//elisp:emacs")],
             providers = [CcInfo],

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -214,7 +214,6 @@ def cc_launcher(ctx, cc_toolchain, src, deps):
         compilation_outputs = objs,
         linking_contexts = [info.linking_context for info in infos],
         user_link_flags = defaults.linkopts,
-        grep_includes = ctx.executable._grep_includes,
     )
     runfiles = ctx.runfiles()
     for dep in deps:


### PR DESCRIPTION
`grep_includes` are not needed anymore in cc_link.