### PR TITLE
Revert "Add a sanity check that the built Emacs binary works"

### DIFF
--- a/emacs/build.py
+++ b/emacs/build.py
@@ -110,11 +110,6 @@ def main() -> None:
     # e.g. https://debbugs.gnu.org/40766).
     for compiled in install.glob('share/emacs/*/lisp/**/*.elc'):
         compiled.with_suffix('.el').unlink()
-    # Sanity check to verify that the resulting binary works.
-    exe_suffix = '.exe' if windows else ''
-    subprocess.run([str(install / 'bin' / ('emacs' + exe_suffix)),
-                    '--quick', '--batch'],
-                   check=True, stdin=subprocess.DEVNULL)
     if args.module_header:
         # Copy emacs-module.h to the desired location.
         shutil.copy(install / 'include' / 'emacs-module.h', args.module_header)


### PR DESCRIPTION
This reverts commit 04ade730f0d32a35b2e4d56c5ee8d4739bedf478.

The sanity check doesn't seem to work right on Windows (doesn't find the portable dump file) and shouldn't be needed.