### PR TITLE
Add a test that the empty binary doesn’t produce output.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -306,6 +306,7 @@ py_library(
     visibility = [
         "//emacs:__pkg__",
         "//examples:__pkg__",
+        "//tests:__pkg__",
         "//tests/wrap:__pkg__",
     ],
     deps = ["@rules_python//python/runfiles"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -18,7 +18,8 @@
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("//elisp:defs.bzl", "elisp_library", "elisp_test")
+load("@rules_python//python:defs.bzl", "py_test")
+load("//elisp:defs.bzl", "elisp_binary", "elisp_library", "elisp_test")
 load(":private/defs.bzl", "elisp_test_suite")
 
 package(
@@ -95,4 +96,25 @@ copy_file(
     testonly = True,
     src = "@junit_xsd//:JUnit.xsd",
     out = "JUnit.xsd",
+)
+
+elisp_binary(
+    name = "empty",
+    src = "empty.el",
+)
+
+py_test(
+    name = "empty_test",
+    size = "medium",
+    timeout = "short",
+    srcs = ["empty_test.py"],
+    args = ["--binary=$(rlocationpath :empty)"],
+    data = [":empty"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "//elisp:runfiles",
+        "@io_abseil_py//absl/flags",
+        "@io_abseil_py//absl/testing:absltest",
+    ],
 )

--- a/tests/empty.el
+++ b/tests/empty.el
@@ -1,0 +1,26 @@
+;;; empty.el --- do nothing -*- lexical-binding: t; -*-
+
+;; Copyright 2023 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;;; Commentary:
+
+;; This is an empty binary that does nothing.  We use it to test that Emacs by
+;; default doesn’t print anything.
+
+;;; Code:
+
+;; Nothing!
+
+;;; empty.el ends here

--- a/tests/empty_test.py
+++ b/tests/empty_test.py
@@ -1,0 +1,49 @@
+# Copyright 2020, 2021, 2022, 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for an empty Emacs Lisp binary."""
+
+import pathlib
+import os
+import subprocess
+
+from absl import flags
+from absl.testing import absltest
+
+from elisp import runfiles
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    'binary', None, 'runfile location of the Emacs Lisp binary to test',
+    required=True)
+
+class EmptyTest(absltest.TestCase):
+    """Unit tests for an empty Emacs Lisp binary."""
+
+    def test_run(self) -> None:
+        """Tests that the empty binary produces empty output."""
+        run_files = runfiles.Runfiles()
+        binary = run_files.resolve(pathlib.PurePosixPath(FLAGS.binary))
+        env = dict(os.environ)
+        env.update(run_files.environment())
+        process = subprocess.run([str(binary)], env=env, check=False,
+                                 stdin=subprocess.DEVNULL, capture_output=True)
+        self.assertEqual(process.returncode, 0)
+        self.assertEmpty(process.stdout)
+        self.assertEmpty(process.stderr)
+
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
Realistically it only produces output if e.g. Emacs can’t find the portable dump file.