### PR TITLE
Revert "Add a workaround for https://github.com/ionelmc/python-lazy-o…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,8 +49,6 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
     name = "pip_deps",
-    # Work around https://github.com/ionelmc/python-lazy-object-proxy/issues/70.
-    extra_pip_args = ["--use-deprecated=legacy-resolver"],
     python_interpreter_target = interpreter,
     requirements_darwin = "@//dev:macos-requirements.txt",
     requirements_linux = "@//dev:linux-requirements.txt",


### PR DESCRIPTION
…bject-proxy/issues/70"

This reverts commit 514d2aaa187fbbbb31574069eb86fa9bd1611dce.

Newer versions of Pylint don't depend on lazy-object-proxy any more, so this workaround should no longer be required.