### PR TITLE
Update rules_python to version 0.26.0.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ module(
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_license", version = "0.0.7")
-bazel_dep(name = "rules_python", version = "0.24.0")
+bazel_dep(name = "rules_python", version = "0.26.0")
 bazel_dep(name = "abseil-cpp", version = "20230125.1", repo_name = "com_google_absl")
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")

--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -53,9 +53,9 @@ def rules_elisp_dependencies():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "0a8003b044294d7840ac7d9d73eef05d6ceb682d7516781a4ec62eeb34702578",
-        strip_prefix = "rules_python-0.24.0",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/0.24.0/rules_python-0.24.0.tar.gz",
+        sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
+        strip_prefix = "rules_python-0.26.0",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
     )
     maybe(
         http_archive,


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_python/releases/tag/0.26.0.