### PR TITLE
Use local_path_override for in-tree repositories.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,4 +84,10 @@ go_deps.module(
 )
 use_repo(go_deps, "com_github_bazelbuild_buildtools", "com_github_google_go_cmp")
 
+# We want to test the external example without adding its repository to the
+# registry.  So we use override the dependency immediately locally.
 bazel_dep(name = "phst_rules_elisp_example", version = "0", dev_dependency = True, repo_name = "example")
+local_path_override(
+    module_name = "phst_rules_elisp_example",
+    path = "examples/ext",
+)

--- a/examples/ext/MODULE.bazel
+++ b/examples/ext/MODULE.bazel
@@ -20,3 +20,7 @@ module(
 )
 
 bazel_dep(name = "phst_rules_elisp", version = "0")
+local_path_override(
+    module_name = "phst_rules_elisp",
+    path = "../..",
+)


### PR DESCRIPTION
This will make the local registry unnecessary.