### PR TITLE
Update to rules_go 0.42.0.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
 # Development-only module dependencies
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True, repo_name = "com_google_googletest")
-bazel_dep(name = "rules_go", version = "0.41.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.42.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
 bazel_dep(name = "abseil-py", version = "1.4.0", dev_dependency = True, repo_name = "io_abseil_py")
 bazel_dep(name = "gazelle", version = "0.32.0", dev_dependency = True, repo_name = "bazel_gazelle")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,10 +123,10 @@ non_module_dev_deps()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
     ],
 )
 
@@ -136,7 +136,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//dev:nogo",
-    version = "1.20.5",
+    version = "1.21.1",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_go/releases/tag/v0.42.0.