### PR TITLE
Update to Skylib 1.5.0.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ module(
 
 # Non-development module dependencies
 bazel_dep(name = "platforms", version = "0.0.7")
-bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_license", version = "0.0.7")
 bazel_dep(name = "rules_python", version = "0.26.0")
 bazel_dep(name = "abseil-cpp", version = "20230802.0", repo_name = "com_google_absl")

--- a/elisp/repositories.bzl
+++ b/elisp/repositories.bzl
@@ -35,10 +35,10 @@ def rules_elisp_dependencies():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+        sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
         ],
     )
     maybe(


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-skylib/releases/tag/1.5.0.