### PR TITLE
Add basic support for external Emacs Lisp dependencies.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,6 +102,10 @@ local_repository(
     path = "examples/ext",
 )
 
+load("@example//:repositories.bzl", "example_dependencies")
+
+example_dependencies()
+
 http_archive(
     name = "com_google_googletest",
     sha256 = "1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -45,6 +45,8 @@ DOCS = [
     "elisp",
     "emacs",
     "repositories",
+    # Requires Bazel 7.  See https://github.com/bazelbuild/stardoc/issues/192.
+    # "extensions",
 ]
 
 merged_manual(
@@ -99,6 +101,19 @@ stardoc(
         "//private:repositories_bzl",
     ],
 )
+
+# Requires Bazel 7.  See https://github.com/bazelbuild/stardoc/issues/192.
+# stardoc(
+#     name = "extensions",
+#     out = "extensions.bin",
+#     format = "proto",
+#     input = "//elisp:extensions.bzl",
+#     deps = [
+#         "//elisp:builtin_bzl",
+#         "//elisp:repositories_bzl",
+#         "//private:repositories_bzl",
+#     ],
+# )
 
 py_binary(
     name = "generate",

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -110,7 +110,17 @@ bzl_library(
 bzl_library(
     name = "repositories_bzl",
     srcs = ["repositories.bzl"],
+    visibility = ["//docs:__pkg__"],
     deps = ["//private:repositories_bzl"],
+)
+
+bzl_library(
+    name = "extensions_bzl",
+    srcs = ["extensions.bzl"],
+    deps = [
+        ":repositories_bzl",
+        "//private:repositories_bzl",
+    ],
 )
 
 bzl_library(
@@ -347,7 +357,9 @@ cc_library(
 
 exports_files(
     [
+        # keep sorted
         "defs.bzl",
+        "extensions.bzl",
         "repositories.bzl",
     ],
     visibility = [

--- a/elisp/extensions.bzl
+++ b/elisp/extensions.bzl
@@ -1,0 +1,48 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module extensions for Emacs Lisp."""
+
+load("//private:repositories.bzl", "HTTP_ARCHIVE_ATTRS", "HTTP_ARCHIVE_DOC")
+load(":repositories.bzl", "elisp_http_archive")
+
+_http_archive = tag_class(
+    doc = HTTP_ARCHIVE_DOC.format(kind = "tag class"),
+    attrs = dict(
+        HTTP_ARCHIVE_ATTRS,
+        name = attr.string(
+            doc = """Name of the workspace to generate.""",
+            mandatory = True,
+        ),
+    ),
+)
+
+def _elisp_impl(module_ctx):
+    """Implementation of the `elisp` module extension."""
+    for module in module_ctx.modules:
+        for arch in module.tags.http_archive:
+            elisp_http_archive(
+                name = arch.name,
+                urls = arch.urls,
+                integrity = arch.integrity,
+                strip_prefix = arch.strip_prefix,
+            )
+
+elisp = module_extension(
+    doc = """Module extension for Emacs Lisp.""",
+    tag_classes = {
+        "http_archive": _http_archive,
+    },
+    implementation = _elisp_impl,
+)

--- a/examples/ext/BUILD
+++ b/examples/ext/BUILD
@@ -26,6 +26,7 @@ elisp_library(
     srcs = ["lib-4.el"],
     load_path = ["."],
     visibility = ["//visibility:public"],
+    deps = ["@dash//:library"],
 )
 
 elisp_test(

--- a/examples/ext/MODULE.bazel
+++ b/examples/ext/MODULE.bazel
@@ -21,3 +21,14 @@ local_path_override(
     module_name = "phst_rules_elisp",
     path = "../..",
 )
+
+elisp = use_extension("@phst_rules_elisp//elisp:extensions.bzl", "elisp")
+elisp.http_archive(
+    name = "dash",
+    integrity = "sha256-FSggKxdDwpkenNRiTcKYPrms/7Neno4OZowSzDZSccU=",
+    strip_prefix = "dash.el-2.19.1/",
+    urls = [
+        "https://github.com/magnars/dash.el/archive/refs/tags/2.19.1.zip",  # 2021-08-26
+    ],
+)
+use_repo(elisp, "dash")

--- a/examples/ext/WORKSPACE
+++ b/examples/ext/WORKSPACE
@@ -43,3 +43,7 @@ http_archive(
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
+
+load(":repositories.bzl", "example_dependencies")
+
+example_dependencies()

--- a/examples/ext/lib-4.el
+++ b/examples/ext/lib-4.el
@@ -1,6 +1,6 @@
 ;;; lib-4.el --- example library 4 -*- lexical-binding: t; -*-
 
-;; Copyright 2020 Google LLC
+;; Copyright 2020, 2023 Google LLC
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 ;; Example library in an external workspace.
 
 ;;; Code:
+
+(require 'dash)  ; from elisp_http_archive rule
 
 (defun lib-4-func ()
   (message "hi from lib-4"))

--- a/examples/ext/repositories.bzl
+++ b/examples/ext/repositories.bzl
@@ -1,0 +1,30 @@
+# Copyright 2023 Philipp Stephani
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains workspace functions for the example repository."""
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@phst_rules_elisp//elisp:repositories.bzl", "elisp_http_archive")
+
+def example_dependencies():
+    """Installs necessary dependencies for the example."""
+    maybe(
+        elisp_http_archive,
+        name = "dash",
+        integrity = "sha256-FSggKxdDwpkenNRiTcKYPrms/7Neno4OZowSzDZSccU=",
+        strip_prefix = "dash.el-2.19.1/",
+        urls = [
+            "https://github.com/magnars/dash.el/archive/refs/tags/2.19.1.zip",  # 2021-08-26
+        ],
+    )

--- a/private/repositories.bzl
+++ b/private/repositories.bzl
@@ -77,3 +77,32 @@ def _toolchains_impl(repository_ctx):
 _toolchains = repository_rule(
     implementation = _toolchains_impl,
 )
+
+HTTP_ARCHIVE_DOC = """Downloads an archive file over HTTP and makes its contents
+available as an `elisp_library`.  This {kind} is very similar to
+[`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive),
+except that it always generates a BUILD file containing a single `elisp_library`
+rule in the root package for all Emacs Lisp files in the archive.
+The `elisp_library` rule is always named `library`."""
+
+HTTP_ARCHIVE_ATTRS = {
+    "urls": attr.string_list(
+        doc = """List of archive URLs to try.
+See the [corresponding attribute for
+`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive-urls).""",
+        mandatory = True,
+        allow_empty = False,
+    ),
+    "integrity": attr.string(
+        doc = """Expected checksum of the archive file in [Subresource
+Integrity](https://www.w3.org/TR/SRI/) format.
+See the [corresponding attribute for
+`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive-integrity).""",
+        mandatory = True,
+    ),
+    "strip_prefix": attr.string(
+        doc = """Directory prefix to strip from the archive contents.
+See the [corresponding attribute for
+`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive-strip_prefix).""",
+    ),
+}


### PR DESCRIPTION
Add a repository rule and an equivalent module extension that behaves like http_archive, but makes the archive contents available as an elisp_library.