### PR TITLE
Remove workaround for https://debbugs.gnu.org/30106.

### DIFF
--- a/emacs/build.py
+++ b/emacs/build.py
@@ -80,10 +80,9 @@ def main() -> None:
     run('./configure', '--prefix=' + install.as_posix(),
         '--without-all', '--without-ns', '--without-x', '--with-x-toolkit=no',
         '--without-libgmp',
-        # Enable threads explicitly to work around https://debbugs.gnu.org/30106
-        # in older Emacs versions.  Enable toolkit scrollbars to work around
+        # Enable toolkit scrollbars to work around
         # https://debbugs.gnu.org/37042.
-        '--with-modules', '--with-threads', '--with-toolkit-scroll-bars',
+        '--with-modules', '--with-toolkit-scroll-bars',
         '--disable-build-details',
         'CC=' + args.cc.resolve().as_posix(),
         'CFLAGS=' + args.cflags,


### PR DESCRIPTION
It’s fixed in all supported versions of Emacs.