### PR TITLE
Run tests under newly-released Bazel 7.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        bazel: [5.4.0, 6.0.0, 6.1.2, 6.2.1, 6.3.2, 6.4.0, latest]
+        bazel: [5.4.0, 6.0.0, 6.1.2, 6.2.1, 6.3.2, 6.4.0, 7.0.0, latest]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # We can’t support older Bazel versions on Windows due to
         # https://github.com/bazelbuild/bazel/issues/15073.


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/releases/tag/7.0.0.