### PR TITLE
Inject current repository name when compiling.

### DIFF
--- a/elisp/compile.el
+++ b/elisp/compile.el
@@ -30,6 +30,8 @@
 (require 'bytecomp)
 (require 'warnings)
 
+(defvar elisp/current-repository)
+
 (add-to-list 'command-switch-alist
              (cons "--fatal-warnings" #'elisp/fatal-warnings))
 
@@ -54,7 +56,7 @@ treat warnings as errors."
   (when elisp/compilation--in-progress
     (error "Recursive invocation of ‘elisp/compile-batch-and-exit’"))
   (pcase command-line-args-left
-    (`(,src ,out)
+    (`(,current-repo ,src ,out)
      (setq command-line-args-left nil)
      (let* ((elisp/compilation--in-progress t)
             ;; Leaving these enabled leads to undefined behavior and doesn’t
@@ -69,11 +71,12 @@ treat warnings as errors."
             (temp (make-temp-file "compile-" nil ".elc"))
             (byte-compile-dest-file-function (lambda (_) temp))
             (byte-compile-error-on-warn elisp/fatal--warnings)
+            (elisp/current-repository current-repo)
             (success (byte-compile-file src)))
        (when success (copy-file temp out :overwrite))
        (delete-file temp)
        (kill-emacs (if success 0 1))))
-    (_ (error "Usage: emacs elisp/compile.el SRC OUT"))))
+    (_ (error "Usage: emacs elisp/compile.el CURRENT-REPO SRC OUT"))))
 
 (defun elisp/fatal-warnings (_arg)
   "Process the --fatal-warnings command-line option."

--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -866,6 +866,7 @@ def _compile(ctx, *, srcs, deps, load_path, data, tags, fatal_warnings):
         if fatal_warnings:
             args.add("--fatal-warnings")
         args.add("--funcall=elisp/compile-batch-and-exit")
+        args.add(ctx.label.workspace_name)
         args.add(src)
         args.add(out)
         run_emacs(

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -421,6 +421,7 @@ def _bootstrap_impl(ctx):
             "--load=" + compile.path,
             "--fatal-warnings",
             "--funcall=elisp/compile-batch-and-exit",
+            ctx.label.workspace_name,
             src.path,
             out.path,
         ],


### PR DESCRIPTION
This should making the runfiles machinery to detect the source repository a bit more robust.