### PR TITLE
Remove uses of `incompatible_use_toolchain_transition`.

### DIFF
--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -414,7 +414,6 @@ as Emacs modules and doesn’t try to byte-compile them.  You can use
 e.g. `cc_binary` with `linkshared = True` to create shared objects.""",
     provides = [EmacsLispInfo],
     toolchains = ["//elisp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _elisp_library_impl,
 )
 
@@ -466,7 +465,6 @@ direct and indirect dependencies.  The feature symbol for `require` is
 corresponding `proto_library` rule.""",
     provides = [EmacsLispInfo],
     toolchains = ["//elisp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _elisp_proto_library_impl,
 )
 
@@ -532,7 +530,6 @@ in batch mode unless `interactive` is `True`.""",
     executable = True,
     fragments = ["cpp"],
     toolchains = use_cpp_toolchain() + ["//elisp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _elisp_binary_impl,
 )
 
@@ -623,7 +620,6 @@ normally pass, but don’t work under coverage for some reason.""",
     fragments = ["cpp"],
     test = True,
     toolchains = use_cpp_toolchain() + ["//elisp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _elisp_test_impl,
 )
 

--- a/emacs/defs.bzl
+++ b/emacs/defs.bzl
@@ -123,7 +123,6 @@ The resulting executable can be used to run the compiled Emacs.""",
     executable = True,
     fragments = ["cpp"],
     toolchains = use_cpp_toolchain(),
-    incompatible_use_toolchain_transition = True,
     implementation = _emacs_binary_impl,
 )
 

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -450,7 +450,6 @@ bootstrap = rule(
     },
     doc = "Primitive version of `elisp_library` used for bootstrapping",
     toolchains = ["//elisp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 def _merged_manual_impl(ctx):


### PR DESCRIPTION
Now that Bazel 7.0 has been released, it's time to remove this tech debt.

This has been a no-op since Bazel 5.0, and @katre has been waiting to remove the code for two years, it's time.

Part of https://github.com/bazelbuild/bazel/issues/14127.