### PR TITLE
Don’t expand cache directories in build.py.

### DIFF
--- a/build.py
+++ b/build.py
@@ -295,8 +295,8 @@ def main() -> None:
                         default='both')
     parser.add_argument('--ignore-lockfile', action='store_true')
     parser.add_argument('--output-base', type=pathlib.Path)
-    parser.add_argument('--action-cache', type=_cache_directory)
-    parser.add_argument('--repository-cache', type=_cache_directory)
+    parser.add_argument('--action-cache', type=pathlib.PurePosixPath)
+    parser.add_argument('--repository-cache', type=pathlib.PurePosixPath)
     parser.add_argument('goals', nargs='*', default=['all'])
     args = parser.parse_args()
     builder = Builder(bazel=args.bazel,
@@ -317,10 +317,6 @@ def _program(name: str) -> pathlib.Path:
     if not file:
         raise FileNotFoundError(f'program {name} not found')
     return pathlib.Path(file)
-
-
-def _cache_directory(arg: str) -> pathlib.Path:
-    return pathlib.Path(arg).expanduser()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bazel already does that if the filename starts with “~/”, see https://bazel.build/remote/caching#disk-cache and the code in com.google.devtools.build.lib.util.OptionsUtils.convertOptionsPathFragment. Because only a literal “~/” prefix is detected, use PurePosixPath instead of Path.