### PR TITLE
Use preprocessor definitions for launchers instead of templates.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -87,8 +87,8 @@ elisp_toolchain(
 )
 
 exports_files([
-    "binary.template",
-    "test.template",
+    "binary_main.cc",
+    "test_main.cc",
 ])
 
 sh_binary(

--- a/elisp/binary_main.cc
+++ b/elisp/binary_main.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021 Google LLC
+// Copyright 2020, 2021, 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ int PHST_RULES_ELISP_MAIN(int argc, phst_rules_elisp::NativeChar** argv) {
   using phst_rules_elisp::NativeString;
   using phst_rules_elisp::RunBinary;
   std::vector<NativeString> args = {
-    [[args]],
+    PHST_RULES_ELISP_ARGS,
     PHST_RULES_ELISP_NATIVE_LITERAL("--")
   };
   args.insert(args.end(), argv, argv + argc);

--- a/elisp/test_main.cc
+++ b/elisp/test_main.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021 Google LLC
+// Copyright 2020, 2021, 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,17 +14,15 @@
 
 #include <vector>
 
-#include "elisp/emacs.h"
+#include "elisp/test.h"
 
 int PHST_RULES_ELISP_MAIN(int argc, phst_rules_elisp::NativeChar** argv) {
-  using phst_rules_elisp::NativeString;
-  using phst_rules_elisp::RunEmacs;
-  std::vector<NativeString> args = {
-    [[args]],
+  std::vector<phst_rules_elisp::NativeString> args = {
+    PHST_RULES_ELISP_ARGS,
     PHST_RULES_ELISP_NATIVE_LITERAL("--")
   };
   args.insert(args.end(), argv, argv + argc);
-  return RunEmacs(argc == 0 ? NativeString() : argv[0], args);
+  return phst_rules_elisp::RunTest(args);
 }
 
 // Local Variables:

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -92,7 +92,7 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-exports_files(srcs = ["launcher.template"])
+exports_files(srcs = ["launcher.cc"])
 
 bzl_library(
     name = "defs_bzl",

--- a/emacs/launcher.cc
+++ b/emacs/launcher.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021 Google LLC
+// Copyright 2020, 2021, 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +14,17 @@
 
 #include <vector>
 
-#include "elisp/test.h"
+#include "elisp/emacs.h"
 
 int PHST_RULES_ELISP_MAIN(int argc, phst_rules_elisp::NativeChar** argv) {
-  std::vector<phst_rules_elisp::NativeString> args = {
-    [[args]],
+  using phst_rules_elisp::NativeString;
+  using phst_rules_elisp::RunEmacs;
+  std::vector<NativeString> args = {
+    PHST_RULES_ELISP_ARGS,
     PHST_RULES_ELISP_NATIVE_LITERAL("--")
   };
   args.insert(args.end(), argv, argv + argc);
-  return phst_rules_elisp::RunTest(args);
+  return RunEmacs(argc == 0 ? NativeString() : argv[0], args);
 }
 
 // Local Variables:


### PR DESCRIPTION
This means that the launcher templates become syntactically valid C++ files.