### PR TITLE
Switch back to default Visual C++.

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -55,16 +55,6 @@ runs:
           mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-xpm-nox
       if: runner.os == 'Windows'
-    - name: Install Visual C++ build tools
-      # Install the 2019 version because Bazel doesn’t support anything newer
-      # in most versions; see
-      # https://bazel.build/install/windows#install-compilers.
-      shell: cmd
-      run: >
-        choco install
-        visualstudio2019buildtools
-        visualstudio2019-workload-vctools
-      if: runner.os == 'Windows'
     - name: Cache Bazel repositories
       uses: actions/cache@v3
       with:

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -58,8 +58,6 @@ jobs:
           -- check
         env:
           USE_BAZEL_VERSION: ${{matrix.bazel}}
-          BAZEL_VC: >-
-            C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC
           # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
           BAZELISK_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Upload profiles

--- a/.github/workflows/debug-cache.yaml
+++ b/.github/workflows/debug-cache.yaml
@@ -40,8 +40,6 @@ jobs:
           -- emacs
         env:
           USE_BAZEL_VERSION: latest
-          BAZEL_VC: >-
-            C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC
           # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
           BAZELISK_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Upload binary execution log

--- a/.github/workflows/update-lockfiles.yaml
+++ b/.github/workflows/update-lockfiles.yaml
@@ -41,8 +41,6 @@ jobs:
           -- lock
         env:
           USE_BAZEL_VERSION: latest
-          BAZEL_VC: >-
-            C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC
           # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
           BAZELISK_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Upload lockfiles


### PR DESCRIPTION
Since Bazel 6.3, Visual C++ 2022 should be supported.  See https://github.com/bazelbuild/bazel/issues/18592 and https://github.com/bazelbuild/bazel/pull/18960.