### PR TITLE
Pass a few data dependencies in flags.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -233,7 +233,10 @@ cc_library(
     srcs = ["binary.cc"],
     hdrs = ["binary.h"],
     copts = COPTS + CXXOPTS,
-    data = [":run_binary_stripped"],
+    data = [
+        ":run_binary_stripped",
+        "//elisp/runfiles:runfiles.elc",
+    ],
     features = FEATURES,
     linkopts = LINKOPTS,
     linkstatic = True,
@@ -241,6 +244,7 @@ cc_library(
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
         shell.quote('RULES_ELISP_RUN_BINARY=R"*($(rlocationpath :run_binary_stripped))*"'),
+        shell.quote('RULES_ELISP_BINARY_ARGS=RULES_ELISP_NATIVE_LITERAL(R"*(--runfiles-elc=$(rlocationpath //elisp/runfiles:runfiles.elc))*")'),
     ],
     visibility = [
         # FIXME: Make private once
@@ -269,6 +273,7 @@ py_test(
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
         shell.quote("--binary=$(rlocationpath :binary_main)"),
+        shell.quote("--binary-cc=$(rlocationpath :binary.cc)"),
     ],
     data = [
         "binary.cc",
@@ -347,7 +352,11 @@ cc_library(
     srcs = ["test.cc"],
     hdrs = ["test.h"],
     copts = COPTS + CXXOPTS,
-    data = [":run_test_stripped"],
+    data = [
+        ":run_test_stripped",
+        "//elisp/ert:runner.elc",
+        "//elisp/runfiles:runfiles.elc",
+    ],
     features = FEATURES,
     linkopts = LINKOPTS,
     linkstatic = True,
@@ -355,6 +364,10 @@ cc_library(
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
         shell.quote('RULES_ELISP_RUN_TEST=R"*($(rlocationpath :run_test_stripped))*"'),
+        shell.quote("RULES_ELISP_TEST_ARGS=" + ", ".join([
+            'RULES_ELISP_NATIVE_LITERAL(R"*(--runfiles-elc=$(rlocationpath //elisp/runfiles:runfiles.elc))*")',
+            'RULES_ELISP_NATIVE_LITERAL(R"*(--runner-elc=$(rlocationpath //elisp/ert:runner.elc))*")',
+        ])),
     ],
     visibility = [
         # FIXME: Make private once
@@ -378,7 +391,6 @@ py_binary(
     name = "run_test",
     testonly = True,
     srcs = ["run_test.py"],
-    data = ["//elisp/ert:runner.elc"],
     python_version = "PY3",
     srcs_version = "PY3",
     deps = [
@@ -415,7 +427,6 @@ py_test(
 py_library(
     name = "load",
     srcs = ["load.py"],
-    data = ["//elisp/runfiles:runfiles.elc"],
     srcs_version = "PY3",
     deps = [":runfiles"],
 )

--- a/elisp/binary.cc
+++ b/elisp/binary.cc
@@ -15,6 +15,7 @@
 #include "elisp/binary.h"
 
 #include <cstdlib>
+#include <vector>
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
@@ -46,7 +47,9 @@ static absl::StatusOr<int> RunBinaryImpl(
   const absl::StatusOr<Runfiles> runfiles =
       Runfiles::Create(BAZEL_CURRENT_REPOSITORY, argv0);
   if (!runfiles.ok()) return runfiles.status();
-  return Run(RULES_ELISP_RUN_BINARY, args, *runfiles);
+  std::vector<NativeString> all_args = {RULES_ELISP_BINARY_ARGS};
+  all_args.insert(all_args.end(), args.begin(), args.end());
+  return Run(RULES_ELISP_RUN_BINARY, all_args, *runfiles);
 }
 
 int RunBinary(const NativeStringView argv0,

--- a/elisp/binary_test.py
+++ b/elisp/binary_test.py
@@ -27,6 +27,7 @@ from elisp import runfiles
 
 
 flags.DEFINE_string('binary', '', 'location of the //elisp:binary_main target')
+flags.DEFINE_string('binary-cc', None, 'location of the //elisp:binary.cc file')
 
 
 class BinaryTest(absltest.TestCase):
@@ -36,7 +37,7 @@ class BinaryTest(absltest.TestCase):
         """Test that running a binary with a wrapper works."""
         run_files = runfiles.Runfiles()
         input_file = run_files.resolve(
-            pathlib.PurePosixPath('phst_rules_elisp/elisp/binary.cc'))
+            pathlib.PurePosixPath(getattr(FLAGS, 'binary-cc')))
         windows = platform.system() == 'Windows'
         args = [
             run_files.resolve(pathlib.PurePosixPath(FLAGS.binary)),
@@ -57,4 +58,5 @@ class BinaryTest(absltest.TestCase):
 
 
 if __name__ == '__main__':
+    flags.mark_flag_as_required('binary-cc')
     absltest.main()

--- a/elisp/load.py
+++ b/elisp/load.py
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Google LLC
+# Copyright 2021, 2022, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,9 @@ import pathlib
 from elisp import runfiles
 
 def add_path(run_files: runfiles.Runfiles, args: list[str],
-             load_path: Iterable[pathlib.PurePosixPath]) -> None:
+             load_path: Iterable[pathlib.PurePosixPath],
+             runfiles_elc: pathlib.PurePosixPath) -> None:
     """Add load path elements to the given args list."""
-    runfiles_elc = pathlib.PurePosixPath(
-        'phst_rules_elisp/elisp/runfiles/runfiles.elc')
     runfile_handler_installed = False
     for directory in load_path:
         try:

--- a/elisp/load_test.py
+++ b/elisp/load_test.py
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023 Google LLC
+# Copyright 2021, 2022, 2023, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ class AddPathTest(absltest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             load.add_path(runfiles.Runfiles({'RUNFILES_DIR': directory}), args,
                           [pathlib.PurePosixPath('foo'),
-                           pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')])
+                           pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')],
+                          pathlib.PurePosixPath(
+                              'phst_rules_elisp/elisp/runfiles/runfiles.elc'))
         base = pathlib.Path(directory)
         self.assertListEqual(
             args,
@@ -56,7 +58,9 @@ class AddPathTest(absltest.TestCase):
                 runfiles.Runfiles({'RUNFILES_MANIFEST_FILE': str(manifest)}),
                 args,
                 [pathlib.PurePosixPath('foo'),
-                 pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')])
+                 pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')],
+                pathlib.PurePosixPath(
+                    'phst_rules_elisp/elisp/runfiles/runfiles.elc'))
         self.assertListEqual(
             args,
             ['--foo',

--- a/elisp/run_binary.py
+++ b/elisp/run_binary.py
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023 Google LLC
+# Copyright 2021, 2022, 2023, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ def main() -> None:
                         default=[])
     parser.add_argument('--wrapper', type=pathlib.PurePosixPath, required=True)
     parser.add_argument('--mode', choices=('direct', 'wrap'), required=True)
+    parser.add_argument('--runfiles-elc', type=pathlib.PurePosixPath,
+                        required=True)
     parser.add_argument('--rule-tag', action='append', default=[])
     parser.add_argument('--load-directory', action='append',
                         type=pathlib.PurePosixPath, default=[])
@@ -62,7 +64,7 @@ def main() -> None:
         args.append('--quick')
         if not opts.interactive:
             args.append('--batch')
-        load.add_path(run_files, args, opts.load_directory)
+        load.add_path(run_files, args, opts.load_directory, opts.runfiles_elc)
         for file in opts.load_file:
             abs_name = run_files.resolve(file)
             args.append('--load=' + str(abs_name))

--- a/elisp/run_test.py
+++ b/elisp/run_test.py
@@ -40,6 +40,10 @@ def main() -> None:
                         default=[])
     parser.add_argument('--wrapper', type=pathlib.PurePosixPath, required=True)
     parser.add_argument('--mode', choices=('direct', 'wrap'), required=True)
+    parser.add_argument('--runfiles-elc', type=pathlib.PurePosixPath,
+                        required=True)
+    parser.add_argument('--runner-elc', type=pathlib.PurePosixPath,
+                        required=True)
     parser.add_argument('--rule-tag', action='append', default=[])
     parser.add_argument('--load-directory', action='append',
                         type=pathlib.PurePosixPath, default=[])
@@ -69,9 +73,8 @@ def main() -> None:
         args += ['--quick', '--batch', '--no-build-details']
         if opts.module_assertions:
             args.append('--module-assertions')
-        load.add_path(run_files, args, opts.load_directory)
-        runner = run_files.resolve(
-            pathlib.PurePosixPath('phst_rules_elisp/elisp/ert/runner.elc'))
+        load.add_path(run_files, args, opts.load_directory, opts.runfiles_elc)
+        runner = run_files.resolve(opts.runner_elc)
         args.append('--load=' + str(runner))
         # Note that using equals signs for --test-source, --skip-test, and
         # --skip-tag doesn’t work.

--- a/elisp/test.cc
+++ b/elisp/test.cc
@@ -15,6 +15,7 @@
 #include "elisp/test.h"
 
 #include <cstdlib>
+#include <vector>
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
@@ -46,7 +47,9 @@ static absl::StatusOr<int> RunTestImpl(
   const absl::StatusOr<Runfiles> runfiles =
       Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY);
   if (!runfiles.ok()) return runfiles.status();
-  return Run(RULES_ELISP_RUN_TEST, args, *runfiles);
+  std::vector<NativeString> all_args = {RULES_ELISP_TEST_ARGS};
+  all_args.insert(all_args.end(), args.begin(), args.end());
+  return Run(RULES_ELISP_RUN_TEST, all_args, *runfiles);
 }
 
 int RunTest(const absl::Span<const NativeString> args) {

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -42,8 +42,12 @@ go_test(
         # See https://github.com/bazelbuild/bazel/issues/12313 why we need to
         # add additional quoting.
         shell.quote("--binary=$(rlocationpath :test_test)"),
+        shell.quote("--test-el=$(rlocationpath :test.el)"),
     ],
-    data = [":test_test"],
+    data = [
+        ":test.el",
+        ":test_test",
+    ],
     embedsrcs = [
         "JUnit.xsd",
         "coverage.dat",

--- a/tests/ert_test.go
+++ b/tests/ert_test.go
@@ -32,14 +32,17 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-var binary = flag.String("binary", "", "location of the binary file relative to the runfiles root")
+var (
+	binary  = flag.String("binary", "", "location of the binary file relative to the runfiles root")
+	test_el = flag.String("test-el", "", "location of //tests:test.el relative to the runfiles root")
+)
 
 func Test(t *testing.T) {
 	rf, err := runfiles.New()
 	if err != nil {
 		t.Fatal(err)
 	}
-	source, err := rf.Rlocation("phst_rules_elisp/tests/test.el")
+	source, err := rf.Rlocation(*test_el)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This again removes a few instances of the hard-coded workspace name.