### PR TITLE
Factor out launcher sources and dependencies into constants.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -16,7 +16,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("//private:defs.bzl", "COPTS", "CXXOPTS", "DEFINES", "FEATURES", "LAUNCHER_COPTS", "LAUNCHER_DEFINES", "LAUNCHER_FEATURES", "LAUNCHER_LINKOPTS", "LINKOPTS", "PACKAGE_FEATURES", "bootstrap", "cc_defaults", "executable_only", "module_config")
+load("//private:defs.bzl", "BINARY_LAUNCHER_DEPS", "BINARY_LAUNCHER_SRCS", "COPTS", "CXXOPTS", "DEFINES", "FEATURES", "LAUNCHER_COPTS", "LAUNCHER_DEFINES", "LAUNCHER_FEATURES", "LAUNCHER_LINKOPTS", "LINKOPTS", "PACKAGE_FEATURES", "TEST_LAUNCHER_DEPS", "TEST_LAUNCHER_SRCS", "bootstrap", "cc_defaults", "executable_only", "module_config")
 load(":defs.bzl", "elisp_binary", "elisp_toolchain")
 
 package(
@@ -200,7 +200,7 @@ executable_only(
 cc_binary(
     name = "binary_main",
     testonly = True,
-    srcs = ["binary_main.cc"],
+    srcs = BINARY_LAUNCHER_SRCS,
     copts = LAUNCHER_COPTS,
     data = [":wrap_stripped"],
     features = LAUNCHER_FEATURES,
@@ -220,7 +220,7 @@ cc_binary(
             'RULES_ELISP_NATIVE_LITERAL("--output-arg=-1")',
         ])),
     ],
-    deps = [":binary"],
+    deps = BINARY_LAUNCHER_DEPS,
 )
 
 build_test(
@@ -328,7 +328,7 @@ executable_only(
 cc_binary(
     name = "test_main",
     testonly = True,
-    srcs = ["test_main.cc"],
+    srcs = TEST_LAUNCHER_SRCS,
     copts = LAUNCHER_COPTS,
     features = LAUNCHER_FEATURES,
     linkopts = LAUNCHER_LINKOPTS,
@@ -338,7 +338,7 @@ cc_binary(
         # add additional quoting.
         shell.quote('RULES_ELISP_ARGS=RULES_ELISP_NATIVE_LITERAL("dummy")'),
     ],
-    deps = [":test"],
+    deps = TEST_LAUNCHER_DEPS,
 )
 
 build_test(

--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -20,8 +20,12 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load(
     "//private:defs.bzl",
+    "BINARY_LAUNCHER_DEPS",
+    "BINARY_LAUNCHER_SRCS",
     "CcDefaultInfo",
     "ModuleConfigInfo",
+    "TEST_LAUNCHER_DEPS",
+    "TEST_LAUNCHER_SRCS",
     "cc_launcher",
     "check_relative_filename",
     "cpp_strings",
@@ -594,11 +598,11 @@ elisp_binary = rule(
             providers = [cc_common.CcToolchainInfo],
         ),
         "_binary_libs": attr.label_list(
-            default = [Label("//elisp:binary")],
+            default = BINARY_LAUNCHER_DEPS,
             providers = [CcInfo],
         ),
         "_launcher_srcs": attr.label_list(
-            default = [Label("//elisp:binary_main.cc")],
+            default = BINARY_LAUNCHER_SRCS,
             allow_files = [".cc"],
         ),
         "_launcher_defaults": attr.label(
@@ -663,11 +667,11 @@ elisp_test = rule(
             providers = [cc_common.CcToolchainInfo],
         ),
         "_test_libs": attr.label_list(
-            default = [Label("//elisp:test")],
+            default = TEST_LAUNCHER_DEPS,
             providers = [CcInfo],
         ),
         "_launcher_srcs": attr.label_list(
-            default = [Label("//elisp:test_main.cc")],
+            default = TEST_LAUNCHER_SRCS,
             allow_files = [".cc"],
         ),
         "_launcher_defaults": attr.label(

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -16,7 +16,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("//private:defs.bzl", "FEATURES", "LAUNCHER_COPTS", "LAUNCHER_DEFINES", "LAUNCHER_FEATURES", "LAUNCHER_LINKOPTS", "PACKAGE_FEATURES", "cc_defaults")
+load("//private:defs.bzl", "EMACS_LAUNCHER_DEPS", "EMACS_LAUNCHER_SRCS", "FEATURES", "LAUNCHER_COPTS", "LAUNCHER_DEFINES", "LAUNCHER_FEATURES", "LAUNCHER_LINKOPTS", "PACKAGE_FEATURES", "cc_defaults")
 load(":defs.bzl", "emacs_binary")
 
 package(
@@ -114,7 +114,7 @@ py_binary(
 cc_binary(
     name = "launcher",
     testonly = True,
-    srcs = ["launcher.cc"],
+    srcs = EMACS_LAUNCHER_SRCS,
     copts = LAUNCHER_COPTS,
     features = LAUNCHER_FEATURES,
     linkopts = LAUNCHER_LINKOPTS,
@@ -124,7 +124,7 @@ cc_binary(
         # add additional quoting.
         shell.quote('RULES_ELISP_ARGS=RULES_ELISP_NATIVE_LITERAL("dummy")'),
     ],
-    deps = ["//elisp:emacs"],
+    deps = EMACS_LAUNCHER_DEPS,
 )
 
 build_test(

--- a/emacs/defs.bzl
+++ b/emacs/defs.bzl
@@ -23,6 +23,8 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_c
 load(
     "//private:defs.bzl",
     "CcDefaultInfo",
+    "EMACS_LAUNCHER_DEPS",
+    "EMACS_LAUNCHER_SRCS",
     "cc_launcher",
     "cpp_string",
     "runfile_location",
@@ -99,11 +101,11 @@ This is used by Gazelle.""",
             providers = [cc_common.CcToolchainInfo],
         ),
         "_emacs_libs": attr.label_list(
-            default = [Label("//elisp:emacs")],
+            default = EMACS_LAUNCHER_DEPS,
             providers = [CcInfo],
         ),
         "_launcher_srcs": attr.label_list(
-            default = [Label("//emacs:launcher.cc")],
+            default = EMACS_LAUNCHER_SRCS,
             allow_files = [".cc"],
         ),
         "_launcher_defaults": attr.label(

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -773,3 +773,10 @@ def _parse_features(features):
         [f for f in features if not f.startswith("-")],
         [f.removeprefix("-") for f in features if f.startswith("-")],
     )
+
+EMACS_LAUNCHER_SRCS = [Label("//emacs:launcher.cc")]
+EMACS_LAUNCHER_DEPS = [Label("//elisp:emacs")]
+BINARY_LAUNCHER_SRCS = [Label("//elisp:binary_main.cc")]
+BINARY_LAUNCHER_DEPS = [Label("//elisp:binary")]
+TEST_LAUNCHER_SRCS = [Label("//elisp:test_main.cc")]
+TEST_LAUNCHER_DEPS = [Label("//elisp:test")]


### PR DESCRIPTION
This allows them to be reused among the launcher test binaries and the rule implementations.