### PR TITLE
Disable compiler parameter files globally.

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -15,5 +15,10 @@
 repo(
     default_applicable_licenses = [":license"],
     default_visibility = ["//visibility:private"],
-    features = ["-macos_default_link_flags"],
+    features = [
+        # On Windows, Bazel generates incorrectly-escaped parameter files.  See
+        # https://github.com/bazelbuild/bazel/issues/21029.
+        "-compiler_param_file",
+        "-macos_default_link_flags",
+    ],
 )

--- a/examples/ext/BUILD
+++ b/examples/ext/BUILD
@@ -18,7 +18,12 @@ package(
     default_applicable_licenses = ["@phst_rules_elisp//:license"],
     default_testonly = True,
     default_visibility = ["//visibility:private"],
-    features = ["-macos_default_link_flags"],
+    features = [
+        # On Windows, Bazel generates incorrectly-escaped parameter files.  See
+        # https://github.com/bazelbuild/bazel/issues/21029.
+        "-compiler_param_file",
+        "-macos_default_link_flags",
+    ],
 )
 
 licenses(["notice"])

--- a/examples/ext/REPO.bazel
+++ b/examples/ext/REPO.bazel
@@ -15,5 +15,10 @@
 repo(
     default_applicable_licenses = ["@phst_rules_elisp//:license"],
     default_visibility = ["//visibility:private"],
-    features = ["-macos_default_link_flags"],
+    features = [
+        # On Windows, Bazel generates incorrectly-escaped parameter files.  See
+        # https://github.com/bazelbuild/bazel/issues/21029.
+        "-compiler_param_file",
+        "-macos_default_link_flags",
+    ],
 )

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -388,14 +388,14 @@ def run_emacs(
 # Features for all packages.  These may not contain select expressions.
 # FIXME: Once all supported Bazel versions parse REPO.bazel, move these features
 # there, and remove them from BUILD files.
-PACKAGE_FEATURES = ["-macos_default_link_flags"]
+PACKAGE_FEATURES = [
+    # On Windows, Bazel generates incorrectly-escaped parameter files.  See
+    # https://github.com/bazelbuild/bazel/issues/21029.
+    "-compiler_param_file",
+    "-macos_default_link_flags",
+]
 
 FEATURES = select({
-    Label("//private:msvc-cl"): [
-        # On Windows, Bazel generates incorrectly-escaped parameter files.  See
-        # https://github.com/bazelbuild/bazel/issues/21029.
-        "-compiler_param_file",
-    ],
     # We can’t use treat_warnings_as_errors on macOS yet because it tries to
     # pass a flag -fatal-warnings to the linker, but the macOS linker accepts
     # -fatal_warnings instead.  See


### PR DESCRIPTION
On Unix they aren’t used anyway, and on Windows they don’t work due to https://github.com/bazelbuild/bazel/issues/21029.