### PR TITLE
Specify BAZEL_USE_CPP_ONLY_TOOLCHAIN in the GitHub workflow.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -61,6 +61,12 @@ jobs:
           USE_BAZEL_VERSION: ${{matrix.bazel}}
           # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467
           BAZELISK_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # We don’t need XCode, and using the Unix toolchain tends to be less
+          # flaky.  See
+          # https://github.com/bazelbuild/bazel/issues/14113#issuecomment-999794586.
+          # Use the Unix toolchain only on Github to make coverage generation
+          # work locally; see https://github.com/bazelbuild/bazel/issues/14970.
+          BAZEL_USE_CPP_ONLY_TOOLCHAIN: '1'
       - name: Upload profiles
         uses: actions/upload-artifact@v4
         with:

--- a/build.py
+++ b/build.py
@@ -265,14 +265,6 @@ class Builder:
         args.extend(targets)
         env = dict(self._env)
         if self._github:
-            if self._kernel == 'Darwin':
-                # We don’t need XCode, and using the Unix toolchain tends to be
-                # less flaky.  See
-                # https://github.com/bazelbuild/bazel/issues/14113#issuecomment-999794586.
-                # Use the Unix toolchain only on Github to make coverage
-                # generation work locally; see
-                # https://github.com/bazelbuild/bazel/issues/14970.
-                env['BAZEL_USE_CPP_ONLY_TOOLCHAIN'] = '1'
             # Hacks so that Bazel finds the right binaries on GitHub.  See
             # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables.
             if self._kernel == 'Windows':


### PR DESCRIPTION
No need to pollute the build script with this.

We only need to do this for bazel-test.yaml because all other workflows run only on Bazel 7, which only ships the Unix toolchain to begin with and ignores the variable.