### PR TITLE
Read another .bazelrc file github.bazelrc if it exists.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,3 +17,5 @@ build --aspects='//private:defs.bzl%check_python'
 build --output_groups='+check_python'
 
 import %workspace%/c-std.bazelrc
+
+try-import %workspace%/github.bazelrc

--- a/examples/ext/.bazelrc
+++ b/examples/ext/.bazelrc
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2023, 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 import %workspace%/../../c-std.bazelrc
+
+try-import %workspace%/../../github.bazelrc


### PR DESCRIPTION
The idea is that the setup action can then put GitHub-specific flags into that file.