### PR TITLE
Remove “profiles” output from setup action.

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -22,9 +22,6 @@ outputs:
   action-cache:
     description: Bazel action cache directory
     value: ${{runner.temp}}/bazel-action-cache
-  profiles:
-    description: Directory where to store Bazel JSON profile files
-    value: ${{runner.temp}}/profiles
 
 runs:
   using: composite

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -54,7 +54,7 @@ jobs:
           --bazel=bazelisk
           --action-cache="${{steps.setup.outputs.action-cache}}"
           --repository-cache="${{steps.setup.outputs.repository-cache}}"
-          --profiles="${{steps.setup.outputs.profiles}}"
+          --profiles="${{runner.temp}}/profiles"
           -- check
         env:
           USE_BAZEL_VERSION: ${{matrix.bazel}}
@@ -70,5 +70,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: profiles for Bazel version ${{matrix.bazel}} on ${{runner.os}}
-          path: ${{steps.setup.outputs.profiles}}/*.json.gz
+          path: ${{runner.temp}}/profiles/*.json.gz
           if-no-files-found: ignore


### PR DESCRIPTION
The setup action doesn’t actually do anything with this directory, so it’s incorrect to have it as action output.