### PR TITLE
Remove --bazel option for the build script.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -64,7 +64,6 @@ jobs:
         # Use disk cache to speed up runs.
         run: >
           python build.py
-          --bazel=bazelisk
           --action-cache="${{steps.setup.outputs.action-cache}}"
           --repository-cache="${{steps.setup.outputs.repository-cache}}"
           --profiles="${{runner.temp}}/profiles"

--- a/.github/workflows/debug-cache.yaml
+++ b/.github/workflows/debug-cache.yaml
@@ -44,7 +44,6 @@ jobs:
         run: >
           echo common --lockfile_mode=off>> github.bazelrc
           && python build.py
-          --bazel=bazelisk
           --action-cache="${{steps.setup.outputs.action-cache}}"
           --repository-cache="${{steps.setup.outputs.repository-cache}}"
           -- emacs

--- a/.github/workflows/update-lockfiles.yaml
+++ b/.github/workflows/update-lockfiles.yaml
@@ -35,7 +35,6 @@ jobs:
         # Use disk cache to speed up runs.
         run: >
           python build.py
-          --bazel=bazelisk
           --action-cache="${{steps.setup.outputs.action-cache}}"
           --repository-cache="${{steps.setup.outputs.repository-cache}}"
           -- lock


### PR DESCRIPTION
We only ever use “bazelisk” or “bazel”.