### PR TITLE
Run Bazel under PowerShell on all platforms.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -63,6 +63,7 @@ jobs:
           !startsWith(matrix.bazel, '6.0.') &&
           !startsWith(matrix.bazel, '6.1.')
       - name: Run Bazel tests
+        shell: pwsh
         run: python build.py --profiles="${{runner.temp}}/profiles" -- check
         env:
           USE_BAZEL_VERSION: ${{matrix.bazel}}

--- a/.github/workflows/debug-cache.yaml
+++ b/.github/workflows/debug-cache.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
       - name: Build Emacs
+        shell: pwsh
         # We don’t care about lockfiles here.
         run: >
           bazelisk build

--- a/.github/workflows/update-lockfiles.yaml
+++ b/.github/workflows/update-lockfiles.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
       - name: Regenerate lockfiles
+        shell: pwsh
         run: python build.py -- lock
         env:
           USE_BAZEL_VERSION: latest


### PR DESCRIPTION
This should work on all
platforms (cf. https://bazel.build/configure/windows#running-bazel-shells), and means we don’t have to write “polyglot” commands.  See https://bazel.build/configure/windows#running-bazel-shells why we don’t use Bash.