### PR TITLE
Use std::map for environment.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -483,7 +483,6 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/cleanup",
-        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",

--- a/elisp/process.cc
+++ b/elisp/process.cc
@@ -447,8 +447,6 @@ absl::StatusOr<int> Run(const std::string_view binary,
     runfiles_args.push_back(RULES_ELISP_NATIVE_LITERAL("--runfiles-env=") +
                             key + RULES_ELISP_NATIVE_LITERAL('=') + value);
   }
-  // Sort entries for hermeticity.
-  absl::c_sort(runfiles_args);
   final_args.insert(final_args.end(), runfiles_args.begin(),
                     runfiles_args.end());
   final_args.insert(final_args.end(), args.begin(), args.end());
@@ -463,8 +461,6 @@ absl::StatusOr<int> Run(const std::string_view binary,
   for (const auto& [key, value] : *map) {
     final_env.push_back(key + RULES_ELISP_NATIVE_LITERAL('=') + value);
   }
-  // Sort entries for hermeticity.
-  absl::c_sort(final_env);
 #ifdef _WIN32
   std::wstring command_line = BuildCommandLine(final_args);
   std::wstring envp = BuildEnvironmentBlock(final_env);

--- a/elisp/process.h
+++ b/elisp/process.h
@@ -19,6 +19,7 @@
 #  error this file requires at least C++17
 #endif
 
+#include <map>
 #include <memory>
 #include <string_view>
 
@@ -33,7 +34,6 @@
 #  pragma warning(push, 3)
 #endif
 #include "absl/base/nullability.h"
-#include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "tools/cpp/runfiles/runfiles.h"
@@ -48,7 +48,7 @@
 
 namespace rules_elisp {
 
-using Environment = absl::flat_hash_map<NativeString, NativeString>;
+using Environment = std::map<NativeString, NativeString>;
 
 class Runfiles final {
  public:


### PR DESCRIPTION
We always sort the environment pairs anyway.