### PR TITLE
Revert "Use std::map for environment."

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -483,6 +483,7 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",

--- a/elisp/process.h
+++ b/elisp/process.h
@@ -19,8 +19,6 @@
 #  error this file requires at least C++17
 #endif
 
-#include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -36,6 +34,7 @@
 #  pragma warning(push, 3)
 #endif
 #include "absl/base/nullability.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
 #include "tools/cpp/runfiles/runfiles.h"
@@ -51,12 +50,14 @@
 namespace rules_elisp {
 
 #ifdef _WIN32
-struct NativeComp;
+struct CaseInsensitiveHash;
+struct CaseInsensitiveEqual;
+using Environment =
+    absl::flat_hash_map<std::wstring, std::wstring, CaseInsensitiveHash,
+                        CaseInsensitiveEqual>;
 #else
-using NativeComp = std::less<std::string>;
+using Environment = absl::flat_hash_map<std::string, std::string>;
 #endif
-
-using Environment = std::map<NativeString, NativeString, NativeComp>;
 
 class Runfiles final {
  public:


### PR DESCRIPTION
This reverts commit f2918a27600d2e0514d69bf05b61de44adc67537.

Let's try to use LCMapString to generate the hash value.