### PR TITLE
Remove unnecessary ctx.resolve_tools(...).

### DIFF
--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -112,18 +112,13 @@ def _elisp_proto_aspect_impl(target, ctx):
     args.add(str(ctx.label))
     args.add(_elisp_proto_feature(src))
     args.add_all(deps, map_each = _elisp_proto_feature)
-    tool_inputs, input_manifests = ctx.resolve_tools(tools = [ctx.attr._generate])
     ctx.actions.run(
         outputs = [src],
-        inputs = depset(
-            direct = [info.direct_descriptor_set],
-            transitive = [tool_inputs],
-        ),
+        inputs = [info.direct_descriptor_set],
         executable = ctx.executable._generate,
         arguments = [args],
         mnemonic = "GenElispProto",
         progress_message = "Generating Emacs Lisp protocol buffer library {}".format(src.short_path),
-        input_manifests = input_manifests,
         toolchain = None,
     )
     load_path = []
@@ -742,15 +737,13 @@ def _elisp_manual_impl(ctx):
     out = ctx.outputs.out
     if out.extension != "texi":
         fail("Output filename {} doesn’t end in “.texi”".format(out.short_path))
-    tool_inputs, input_manifests = ctx.resolve_tools(tools = [ctx.attr._export])
     ctx.actions.run(
         outputs = [out],
-        inputs = depset(direct = [src], transitive = [tool_inputs]),
+        inputs = [src],
         executable = ctx.executable._export,
         arguments = [ctx.actions.args().add(src).add(out)],
         mnemonic = "Export",
         progress_message = "Exporting {} into Texinfo file".format(src.short_path),
-        input_manifests = input_manifests,
         toolchain = None,
     )
 

--- a/emacs/defs.bzl
+++ b/emacs/defs.bzl
@@ -202,12 +202,11 @@ def _install(ctx, cc_toolchain, readme):
     if ctx.outputs.builtin_features:
         args.add(ctx.outputs.builtin_features, format = "--builtin-features=%s")
         outs.append(ctx.outputs.builtin_features)
-    tool_inputs, input_manifests = ctx.resolve_tools(tools = [ctx.attr._build])
     ctx.actions.run(
         outputs = outs,
         inputs = depset(
             direct = ctx.files.srcs,
-            transitive = [cc_toolchain.all_files, tool_inputs],
+            transitive = [cc_toolchain.all_files],
         ),
         executable = ctx.executable._build,
         arguments = [args],
@@ -216,7 +215,6 @@ def _install(ctx, cc_toolchain, readme):
             "Installing Emacs into {}".format(install.short_path)
         ),
         env = env,
-        input_manifests = input_manifests,
         toolchain = None,
     )
     return install


### PR DESCRIPTION
Using ctx.actions.run(executable = ...) is sufficient to ensure that the runfiles are present.

Originally by @tjgq.