### PR TITLE
Simplify launcher code.

### DIFF
--- a/elisp/binary.h
+++ b/elisp/binary.h
@@ -19,6 +19,8 @@
 #  error this file requires at least C++17
 #endif
 
+#include <initializer_list>
+
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wpedantic"
@@ -30,7 +32,6 @@
 #  pragma warning(push, 3)
 #endif
 #include "absl/base/attributes.h"
-#include "absl/types/span.h"
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
@@ -42,8 +43,9 @@
 
 namespace rules_elisp {
 
-ABSL_MUST_USE_RESULT int RunBinary(NativeStringView argv0,
-                                   absl::Span<const NativeString> args);
+ABSL_MUST_USE_RESULT int RunBinary(
+    std::initializer_list<NativeStringView> prefix, int argc,
+    const NativeChar* const* argv);
 
 }  // namespace rules_elisp
 

--- a/elisp/binary_main.cc
+++ b/elisp/binary_main.cc
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
-
 #include "elisp/binary.h"
 
 int RULES_ELISP_MAIN(int argc, rules_elisp::NativeChar** argv) {
-  using rules_elisp::NativeString;
-  std::vector<NativeString> args = {RULES_ELISP_ARGS,
-                                    RULES_ELISP_NATIVE_LITERAL("--")};
-  args.insert(args.end(), argv, argv + argc);
-  return rules_elisp::RunBinary(argc == 0 ? NativeString() : argv[0], args);
+  return rules_elisp::RunBinary({RULES_ELISP_ARGS}, argc, argv);
 }

--- a/elisp/emacs.h
+++ b/elisp/emacs.h
@@ -19,6 +19,8 @@
 #  error this file requires at least C++17
 #endif
 
+#include <initializer_list>
+
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wpedantic"
@@ -30,7 +32,6 @@
 #  pragma warning(push, 3)
 #endif
 #include "absl/base/attributes.h"
-#include "absl/types/span.h"
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
@@ -42,8 +43,9 @@
 
 namespace rules_elisp {
 
-ABSL_MUST_USE_RESULT int RunEmacs(NativeStringView argv0,
-                                  absl::Span<const NativeString> args);
+ABSL_MUST_USE_RESULT int RunEmacs(
+    std::initializer_list<NativeStringView> prefix, int argc,
+    const NativeChar* const* argv);
 
 }  // namespace rules_elisp
 

--- a/elisp/test.h
+++ b/elisp/test.h
@@ -19,6 +19,8 @@
 #  error this file requires at least C++17
 #endif
 
+#include <initializer_list>
+
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wpedantic"
@@ -30,7 +32,6 @@
 #  pragma warning(push, 3)
 #endif
 #include "absl/base/attributes.h"
-#include "absl/types/span.h"
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
@@ -42,7 +43,8 @@
 
 namespace rules_elisp {
 
-ABSL_MUST_USE_RESULT int RunTest(absl::Span<const NativeString> args);
+ABSL_MUST_USE_RESULT int RunTest(std::initializer_list<NativeStringView> prefix,
+                                 int argc, const NativeChar* const* argv);
 
 }  // namespace rules_elisp
 

--- a/elisp/test_main.cc
+++ b/elisp/test_main.cc
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
-
 #include "elisp/test.h"
 
 int RULES_ELISP_MAIN(int argc, rules_elisp::NativeChar** argv) {
-  using rules_elisp::NativeString;
-  std::vector<NativeString> args = {RULES_ELISP_ARGS,
-                                    RULES_ELISP_NATIVE_LITERAL("--")};
-  args.insert(args.end(), argv, argv + argc);
-  return rules_elisp::RunTest(args);
+  return rules_elisp::RunTest({RULES_ELISP_ARGS}, argc, argv);
 }

--- a/emacs/launcher.cc
+++ b/emacs/launcher.cc
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
-
 #include "elisp/emacs.h"
 
 int RULES_ELISP_MAIN(int argc, rules_elisp::NativeChar** argv) {
-  using rules_elisp::NativeString;
-  std::vector<NativeString> args = {RULES_ELISP_ARGS,
-                                    RULES_ELISP_NATIVE_LITERAL("--")};
-  args.insert(args.end(), argv, argv + argc);
-  return rules_elisp::RunEmacs(argc == 0 ? NativeString() : argv[0], args);
+  return rules_elisp::RunEmacs({RULES_ELISP_ARGS}, argc, argv);
 }


### PR DESCRIPTION
Build up argument lists in the helper libraries instead of the main function.