### PR TITLE
Rename all the main functions to just “Main”.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -181,7 +181,7 @@ cc_binary(
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
         shell.quote('RULES_ELISP_HEADER="elisp/binary.h"'),
-        shell.quote("RULES_ELISP_FUNCTION=RunBinary"),
+        shell.quote("RULES_ELISP_FUNCTION=Main"),
         shell.quote("RULES_ELISP_ARGS=" + ", ".join([
             'RULES_ELISP_NATIVE_LITERAL(R"*(--wrapper=$(rlocationpath :wrap_stripped))*")',
             'RULES_ELISP_NATIVE_LITERAL("--mode=wrap")',

--- a/elisp/binary.cc
+++ b/elisp/binary.cc
@@ -43,7 +43,7 @@
 
 namespace rules_elisp {
 
-absl::StatusOr<int> RunBinary(
+absl::StatusOr<int> Main(
     const std::initializer_list<NativeStringView> prefix,
     const absl::Span<const absl::Nonnull<const NativeChar*>> suffix) {
   const absl::StatusOr<Runfiles> runfiles =

--- a/elisp/binary.h
+++ b/elisp/binary.h
@@ -45,7 +45,7 @@
 
 namespace rules_elisp {
 
-absl::StatusOr<int> RunBinary(
+absl::StatusOr<int> Main(
     std::initializer_list<NativeStringView> prefix,
     absl::Span<const absl::Nonnull<const NativeChar*>> suffix);
 

--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -199,7 +199,7 @@ def _elisp_binary_impl(ctx):
         srcs = ctx.files.src,
         tags = [],
         header = "elisp/binary.h",
-        function = "RunBinary",
+        function = "Main",
         args = args,
     )
     return [
@@ -229,7 +229,7 @@ def _elisp_test_impl(ctx):
         # cf. https://bazel.build/reference/be/common-definitions#test.local.
         tags = ["local"] if ctx.attr.local else [],
         header = "elisp/test.h",
-        function = "RunTest",
+        function = "Main",
         args = args,
     )
 

--- a/elisp/emacs.cc
+++ b/elisp/emacs.cc
@@ -43,7 +43,7 @@
 
 namespace rules_elisp {
 
-absl::StatusOr<int> RunEmacs(
+absl::StatusOr<int> Main(
     const std::initializer_list<NativeStringView> prefix,
     const absl::Span<const absl::Nonnull<const NativeChar*>> suffix) {
   const absl::StatusOr<Runfiles> runfiles =

--- a/elisp/emacs.h
+++ b/elisp/emacs.h
@@ -45,7 +45,7 @@
 
 namespace rules_elisp {
 
-absl::StatusOr<int> RunEmacs(
+absl::StatusOr<int> Main(
     std::initializer_list<NativeStringView> prefix,
     absl::Span<const absl::Nonnull<const NativeChar*>> suffix);
 

--- a/elisp/test.cc
+++ b/elisp/test.cc
@@ -43,7 +43,7 @@
 
 namespace rules_elisp {
 
-absl::StatusOr<int> RunTest(
+absl::StatusOr<int> Main(
     const std::initializer_list<NativeStringView> prefix,
     const absl::Span<const absl::Nonnull<const NativeChar*>> suffix) {
   const absl::StatusOr<Runfiles> runfiles =

--- a/elisp/test.h
+++ b/elisp/test.h
@@ -45,7 +45,7 @@
 
 namespace rules_elisp {
 
-absl::StatusOr<int> RunTest(
+absl::StatusOr<int> Main(
     std::initializer_list<NativeStringView> prefix,
     absl::Span<const absl::Nonnull<const NativeChar*>> suffix);
 

--- a/emacs/defs.bzl
+++ b/emacs/defs.bzl
@@ -41,7 +41,7 @@ def _emacs_binary_impl(ctx):
     executable, runfiles = cc_launcher(
         ctx,
         header = "elisp/emacs.h",
-        function = "RunEmacs",
+        function = "Main",
         args = [
             "--install=" + runfile_location(ctx, install),
         ],


### PR DESCRIPTION
We have exactly one of those in each launcher program.