### PR TITLE
Treat external repositories as system headers for warning purposes.

### DIFF
--- a/examples/ext/REPO.bazel
+++ b/examples/ext/REPO.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023, 2024 Philipp Stephani
+# Copyright 2023, 2024, 2025 Philipp Stephani
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -433,6 +433,8 @@ LAUNCHER_FEATURES = FEATURES
 COPTS = select({
     Label("@rules_cc//cc/compiler:msvc-cl"): [
         "/W4",
+        "/external:W3",  # TODO: shouldn’t be needed; file bug against Bazel
+        "/external:Iexternal",  # TODO: shouldn’t be needed; file bug against Bazel
         "/utf-8",
         "/permissive-",
         "/Zc:__cplusplus",


### PR DESCRIPTION
This should reduce the noise necessary to disable warnings.