### PR TITLE
Replace instances of struct.to_json with json.encode(...)

### DIFF
--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -359,7 +359,7 @@ def run_emacs(
         )
         ctx.actions.write(
             output = manifest,
-            content = struct(
+            content = json.encode(struct(
                 root = "EXECUTION_ROOT",
                 loadPath = manifest_load_path,
                 inputFiles = [
@@ -370,7 +370,7 @@ def run_emacs(
                 ],
                 outputFiles = [f.path for f in outputs],
                 tags = tags,
-            ).to_json(),
+            )),
         )
         arguments = [
             ctx.actions.args().add(manifest, format = "--manifest=%s").add("--"),


### PR DESCRIPTION
The "to_json" method on Starlark structs is deprecated and should not be used. Instead, the json module (https://bazel.build/rules/lib/core/json) should be used.