### PR TITLE
Indirect fields of ctx.attr.<name> through DefaultInfo.

### DIFF
--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -1118,7 +1118,7 @@ def _binary(ctx, *, srcs, tags, args):
         ctx,
         header = "elisp/binary.h",
         args = [
-            "--wrapper=" + runfile_location(ctx, emacs.files_to_run.executable),
+            "--wrapper=" + runfile_location(ctx, emacs[DefaultInfo].files_to_run.executable),
             "--mode=" + ("wrap" if toolchain.wrap else "direct"),
         ] + [
             "--rule-tag=" + tag
@@ -1135,13 +1135,13 @@ def _binary(ctx, *, srcs, tags, args):
         ] + args,
     )
     bin_runfiles = ctx.runfiles(
-        files = [emacs.files_to_run.executable] + result.outs,
+        files = [emacs[DefaultInfo].files_to_run.executable] + result.outs,
         transitive_files = depset(
             transitive = [transitive_files, result.runfiles.files],
         ),
         root_symlinks = links,
     )
-    emacs_runfiles = emacs.default_runfiles
+    emacs_runfiles = emacs[DefaultInfo].default_runfiles
     runfiles = bin_runfiles.merge(emacs_runfiles).merge(launcher_runfiles)
     return executable, runfiles
 


### PR DESCRIPTION
Direct access is going away; this commit updates the code for that.