### PR TITLE
Drop support for Bazel versions older than 6.3.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -29,14 +29,10 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        bazel: [6.0.0, 6.3.2, 6.5.0, 7.1.1, latest]
+        bazel: [6.3.2, 6.5.0, 7.1.1, latest]
         os: [ubuntu-latest, macos-latest, windows-latest]
         cc: [gcc, clang, msvc]
         exclude:
-          # We can’t support older Bazel versions on Windows due to
-          # https://github.com/bazelbuild/bazel/issues/15073.
-          - bazel: 6.0.0
-            os: windows-latest
           # Visual C++ works only on Windows.  Windows doesn’t use the CC
           # environment variable and always uses Visual C++ by default.
           - os: ubuntu-latest
@@ -71,10 +67,6 @@ jobs:
           echo common
           --lockfile_mode=${{matrix.bazel == 'latest' && 'error' || 'off'}}>>
           github.bazelrc
-        # The --lockfile_mode flag was introduced in Bazel 6.2.
-        if: >-
-          !startsWith(matrix.bazel, '6.0.') &&
-          !startsWith(matrix.bazel, '6.1.')
       - name: Run Bazel tests
         shell: pwsh
         run: python build.py --profiles='${{runner.temp}}/profiles' -- check

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 # Note that the versions library only works within a WORKSPACE file, see
 # https://github.com/bazelbuild/bazel/issues/8305.
-versions.check("6.0.0")
+versions.check("6.3.0")
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 

--- a/docs/manual.org
+++ b/docs/manual.org
@@ -39,7 +39,7 @@ This is not an officially supported Google product.
 To use ~rules_elisp~, you need [[https://bazel.build/][Bazel]].  For
 installation instructions, see [[https://bazel.build/install][Installing
 Bazel]].  This repository supports all full Bazel releases starting with Bazel
-5.4.0.  You’ll also need a recent C/C++ compiler (GCC or Clang on GNU/Linux and
+6.3.0.  You’ll also need a recent C/C++ compiler (GCC or Clang on GNU/Linux and
 macOS, Visual C++ 2019 on Windows) and at least Python 3.10.  For further
 instructions how to use Bazel on Windows, see
 [[https://bazel.build/install/windows][Installing Bazel on Windows]].  On
@@ -66,8 +66,7 @@ git_override(
 
 #+TEXINFO: @noindent
 See [[https://bazel.build/external/overview#bzlmod][the Bzlmod documentation]]
-for background information.  Due to various Bzlmod-related bugs in older Bazel
-versions, this approach requires at least Bazel 6.3.
+for background information.
 
 Alternatively, if you’re not using Bzlmod, add a snippet like the following to
 your Bazel ~WORKSPACE~ file:


### PR DESCRIPTION
Protocol Buffers 26 will require at least Bazel 6.3.