### PR TITLE
Support Emacs source archives in emacs_binary.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1887,7 +1887,7 @@
   "moduleExtensions": {
     "//elisp:extensions.bzl%elisp": {
       "general": {
-        "bzlTransitiveDigest": "ZcHLTKibaxVyb2cq5VCyeNfycc+5kW8LolGTwq9q99M=",
+        "bzlTransitiveDigest": "DRUfuSRxm1EALS6A7laxabg5Gtm9ce6qd9f/tVFzBdk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1919,7 +1919,7 @@
     },
     "//private:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "CvXEGOETEZaOsCc5g38wFWYtZvKYBnyfNQV31qxRJ5Y=",
+        "bzlTransitiveDigest": "rNWhgxHuuaDXfsuG1MqSptfDPCj+Fw07cIbgTeKexIE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1935,6 +1935,7 @@
             "attributes": {
               "path": "/emacs/emacs-29.3.tar.xz",
               "integrity": "sha256-w0wF06zmZu2cf3oPrwcP6jIX/xkQ0ARJm9VFMjPXQqA=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-29.3"
             }
           },
@@ -1944,6 +1945,7 @@
             "attributes": {
               "path": "/emacs/emacs-29.2.tar.xz",
               "integrity": "sha256-fT0kSJiHIL9L9XrXeloIvyLfJhYPkFB6hBuphr4mcNw=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-29.2"
             }
           },
@@ -1953,6 +1955,7 @@
             "attributes": {
               "path": "/emacs/emacs-28.2.tar.xz",
               "integrity": "sha256-7iEYIjPvMjLcl7SGry2G4UBC27ZbvFNd9WLDqFgjJIg=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-28.2"
             }
           },
@@ -1962,6 +1965,7 @@
             "attributes": {
               "path": "/emacs/emacs-29.1.tar.xz",
               "integrity": "sha256-0viBpcwjHi9aA+hvRYSwQ4+D7ddZignSSiG9jQA+LgE=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-29.1"
             }
           },
@@ -1971,6 +1975,7 @@
             "attributes": {
               "path": "/emacs/emacs-28.1.tar.xz",
               "integrity": "sha256-KLGz0JkDegiPCkyiUdfnJi6rXqFneqv/psRCaWGtdeE=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-28.1"
             }
           }
@@ -1980,7 +1985,7 @@
     },
     "//private:extensions.bzl%non_module_dev_deps": {
       "general": {
-        "bzlTransitiveDigest": "CvXEGOETEZaOsCc5g38wFWYtZvKYBnyfNQV31qxRJ5Y=",
+        "bzlTransitiveDigest": "rNWhgxHuuaDXfsuG1MqSptfDPCj+Fw07cIbgTeKexIE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/emacs.BUILD
+++ b/emacs.BUILD
@@ -29,13 +29,10 @@ package(
 
 emacs_binary(
     name = "emacs",
-    srcs = glob(
-        ["**"],
-        allow_empty = False,
-    ),
+    srcs = ["[src]"],
     builtin_features = "builtin_features.json",
     module_header = "emacs-module.h",
-    readme = "README",
+    strip_prefix = "[strip_prefix]",
     visibility = ["[emacs_pkg]"],
 )
 

--- a/examples/ext/MODULE.bazel.lock
+++ b/examples/ext/MODULE.bazel.lock
@@ -1429,7 +1429,7 @@
     },
     "@@phst_rules_elisp~//elisp:extensions.bzl%elisp": {
       "general": {
-        "bzlTransitiveDigest": "ZcHLTKibaxVyb2cq5VCyeNfycc+5kW8LolGTwq9q99M=",
+        "bzlTransitiveDigest": "DRUfuSRxm1EALS6A7laxabg5Gtm9ce6qd9f/tVFzBdk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1461,7 +1461,7 @@
     },
     "@@phst_rules_elisp~//private:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "CvXEGOETEZaOsCc5g38wFWYtZvKYBnyfNQV31qxRJ5Y=",
+        "bzlTransitiveDigest": "rNWhgxHuuaDXfsuG1MqSptfDPCj+Fw07cIbgTeKexIE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1477,6 +1477,7 @@
             "attributes": {
               "path": "/emacs/emacs-29.3.tar.xz",
               "integrity": "sha256-w0wF06zmZu2cf3oPrwcP6jIX/xkQ0ARJm9VFMjPXQqA=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-29.3"
             }
           },
@@ -1486,6 +1487,7 @@
             "attributes": {
               "path": "/emacs/emacs-29.2.tar.xz",
               "integrity": "sha256-fT0kSJiHIL9L9XrXeloIvyLfJhYPkFB6hBuphr4mcNw=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-29.2"
             }
           },
@@ -1495,6 +1497,7 @@
             "attributes": {
               "path": "/emacs/emacs-28.2.tar.xz",
               "integrity": "sha256-7iEYIjPvMjLcl7SGry2G4UBC27ZbvFNd9WLDqFgjJIg=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-28.2"
             }
           },
@@ -1504,6 +1507,7 @@
             "attributes": {
               "path": "/emacs/emacs-29.1.tar.xz",
               "integrity": "sha256-0viBpcwjHi9aA+hvRYSwQ4+D7ddZignSSiG9jQA+LgE=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-29.1"
             }
           },
@@ -1513,6 +1517,7 @@
             "attributes": {
               "path": "/emacs/emacs-28.1.tar.xz",
               "integrity": "sha256-KLGz0JkDegiPCkyiUdfnJi6rXqFneqv/psRCaWGtdeE=",
+              "output": "emacs.tar.xz",
               "strip_prefix": "emacs-28.1"
             }
           }

--- a/private/repositories.bzl
+++ b/private/repositories.bzl
@@ -109,18 +109,20 @@ def _emacs(*, version, integrity):
         name = "gnu_emacs_" + version,
         path = "/emacs/emacs-{}.tar.xz".format(version),
         integrity = integrity,
+        output = "emacs.tar.xz",
         strip_prefix = "emacs-{}".format(version),
     )
 
 def _emacs_repository_impl(ctx):
     path = ctx.attr.path
-    ctx.download_and_extract(
+    output = ctx.attr.output
+    ctx.download(
         integrity = ctx.attr.integrity,
         url = [
             "https://ftpmirror.gnu.org" + path,
             "https://ftp.gnu.org/gnu" + path,
         ],
-        stripPrefix = ctx.attr.strip_prefix,
+        output = output,
     )
     ctx.template(
         "BUILD.bazel",
@@ -128,6 +130,8 @@ def _emacs_repository_impl(ctx):
         {
             '"[defs_bzl]"': repr(str(Label("//emacs:defs.bzl"))),
             '"[emacs_pkg]"': repr(str(Label("//emacs:__pkg__"))),
+            '"[src]"': repr(output),
+            '"[strip_prefix]"': repr(ctx.attr.strip_prefix),
         },
         executable = False,
     )
@@ -136,6 +140,7 @@ _emacs_repository = repository_rule(
     attrs = {
         "path": attr.string(mandatory = True),
         "integrity": attr.string(mandatory = True),
+        "output": attr.string(mandatory = True),
         "strip_prefix": attr.string(),
     },
     implementation = _emacs_repository_impl,


### PR DESCRIPTION
This allows us to drop the README hack.