### PR TITLE
Revert "Install missing ‘realpath’ binary on macOS."

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -42,11 +42,6 @@ runs:
       shell: bash
       run: sudo apt-get update && sudo apt-get install libxml2-utils
       if: runner.os == 'Linux'
-    - name: Install Homebrew packages
-      # The Protocol Buffer rules need ‘realpath’ from the GNU coreutils.
-      shell: bash
-      run: brew update && brew install coreutils
-      if: runner.os == 'macOS'
     - name: Install MSYS2
       uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
This reverts commit 90456291001a8fd952c4bfba6fa1e411f33a5838.

This should no longer be needed with newer Protobuf versions.