### PR TITLE
Fix dependency issue with absl.flags.FLAGS.

### DIFF
--- a/elisp/binary_test.py
+++ b/elisp/binary_test.py
@@ -19,12 +19,12 @@ import platform
 import subprocess
 
 from absl import flags
-from absl.flags import FLAGS
 from absl.testing import absltest
 
 from elisp import runfiles
 
 
+FLAGS = flags.FLAGS
 flags.DEFINE_string(
     'launcher', None, 'location of the //elisp:launcher target', required=True)
 flags.DEFINE_string(


### PR DESCRIPTION
Current code fails with strict dependencies:
```
ERROR: Strict deps violations: //third_party/elisp/rules/elisp:binary_test
  In third_party/elisp/rules/elisp/binary_test.py, no direct deps found for imports:
    line 22: from absl.flags import FLAGS: Ambiguous import: "FLAGS" from package "absl.flags": cannot determine whether "FLAGS" is an attribute on the package, or a module not provided by a direct dependency. See go/py-strict-deps#package-imports
```