### PR TITLE
Update to Gazelle 0.36.0.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "protobuf", version = "26.0.bcr.1", repo_name = "com_google_pro
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "rules_go", version = "0.48.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
 bazel_dep(name = "abseil-py", version = "1.4.0", dev_dependency = True, repo_name = "io_abseil_py")
-bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 
 # Bring in the local_config_cc repository.  It’s needed for
 # //emacs:windows_cc_toolchain.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "f02a9d3bf32d38694c882ea185001cd51f8dc96c77bee8d9a9a099e9cfa17fbf",
+  "moduleFileHash": "675b3185b3672fbd055f2f474616c2ef4e2ac72b12bee254fe44c3d759128c10",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -176,9 +176,9 @@ buildifier_prebuilt_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "32938bda16e6700063035479063d9d24c60eda8d79fd4739563f50d331cb3209",
+    sha256 = "75df288c4b31c81eb50f51e2e14f4763cb7548daae126817247064637fd9ea62",
     urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",  # 2023-12-21
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz",  # 2024-04-03
     ],
 )
 

--- a/examples/ext/MODULE.bazel.lock
+++ b/examples/ext/MODULE.bazel.lock
@@ -14,7 +14,7 @@
   },
   "localOverrideHashes": {
     "bazel_tools": "1ae69322ac3823527337acf02016e8ee95813d8d356f47060255b8956fa642f0",
-    "phst_rules_elisp": "f02a9d3bf32d38694c882ea185001cd51f8dc96c77bee8d9a9a099e9cfa17fbf"
+    "phst_rules_elisp": "675b3185b3672fbd055f2f474616c2ef4e2ac72b12bee254fe44c3d759128c10"
   },
   "moduleDepGraph": {
     "<root>": {


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-gazelle/releases/tag/v0.36.0.