### PR TITLE
Remove unused functionality to exclude tags from the manual.

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -53,7 +53,6 @@ DOCS = [
 merged_manual(
     name = "merged_manual",
     out = "merged.org",
-    exclude_tag = "",
     includes = DOCS,
     main = "manual.org",
     tags = STARDOC_TAGS,
@@ -63,10 +62,10 @@ elisp_binary(
     name = "merge",
     src = "merge.el",
     input_args = list(range(
-        3,
-        len(DOCS) + 4,
+        2,
+        len(DOCS) + 3,
     )),
-    output_args = [2],
+    output_args = [1],
 )
 
 stardoc(

--- a/docs/manual.org
+++ b/docs/manual.org
@@ -678,7 +678,7 @@ from {{{var(array)}}}.  Elements are shifted left to fill in the hole.
 
 #+INCLUDE: repositories.org
 
-** Symbols defined in =//elisp:extensions.bzl=                   :extensions:
+** Symbols defined in =//elisp:extensions.bzl=
 :PROPERTIES:
 :ALT_TITLE: Extension Starlark symbols
 :END:

--- a/docs/merge.el
+++ b/docs/merge.el
@@ -26,7 +26,7 @@
 (unless noninteractive (user-error "This file works only in batch mode"))
 
 (pcase command-line-args-left
-  (`(,exclude ,output ,main . ,includes)
+  (`(,output ,main . ,includes)
    (setq command-line-args-left nil)
    (let ((coding-system-for-read 'utf-8-unix)
          (coding-system-for-write 'utf-8-unix)
@@ -40,11 +40,9 @@
      (with-temp-buffer
        (insert-file-contents main :visit)
        (org-mode)
-       (unless (string-empty-p exclude)
-         (org-map-entries #'org-cut-subtree exclude))
        (org-export-expand-include-keyword nil temp-dir)
        (write-region nil nil output))
      (delete-directory temp-dir :recursive)))
-  (_ (user-error "Usage: docs/merge EXCLUDE OUTPUT.org MAIN.org INCLUDE.org…")))
+  (_ (user-error "Usage: docs/merge OUTPUT.org MAIN.org INCLUDE.org…")))
 
 ;;; merge.el ends here

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -652,7 +652,6 @@ def _merged_manual_impl(ctx):
         orgs.append(org)
 
     args = ctx.actions.args()
-    args.add(ctx.attr.exclude_tag)
     args.add(ctx.outputs.out)
     args.add(ctx.file.main)
     args.add_all(orgs, expand_directories = False)
@@ -678,7 +677,6 @@ merged_manual = rule(
             allow_empty = False,
         ),
         "out": attr.output(mandatory = True),
-        "exclude_tag": attr.string(mandatory = True),
         "_generate": attr.label(
             executable = True,
             cfg = "exec",


### PR DESCRIPTION
This partially reverts commit 8186377e787a0be4a8d9cdc14ccf7cd3628453d4.