### PR TITLE
Mimic some aspects of file visiting.

### DIFF
--- a/elisp/export-org.el
+++ b/elisp/export-org.el
@@ -45,7 +45,8 @@
          (org-export-time-stamp-file nil)
          (org-export-use-babel nil))
      (with-temp-buffer
-       (insert-file-contents input)
+       (insert-file-contents input :visit)
+       (setq default-directory (file-name-directory input))
        (write-region (org-export-as 'texinfo) nil output))))
   (_ (user-error "Usage: elisp/export-org INPUT OUTPUT")))
 


### PR DESCRIPTION
Set ‘default-directory’ to the directory of the visited file so that relative filenames are interpreted correctly.