### PR TITLE
Support space and backslash characters in runfile filenames.

### DIFF
--- a/elisp/runfiles/runfiles-test.el
+++ b/elisp/runfiles/runfiles-test.el
@@ -54,8 +54,17 @@
                     "phst_rules_elisp/elisp/runfiles/test-manifest"))
          (runfiles (elisp/runfiles/make :manifest manifest
                                         :directory "/invalid/")))
-    (should (equal (elisp/runfiles/rlocation "testäα𝐴🐈'.txt" runfiles)
-                   "/:/runfiles/testäα𝐴🐈'.txt"))))
+    (pcase-dolist (`(,source ,target)
+                   '(("testäα𝐴🐈'.txt"
+                      "/:/runfiles/testäα𝐴🐈'.txt")
+                     ("target-with-space"
+                      "/:/runfiles/with space\\and backslash")
+                     ("target-with-newline"
+                      "/:/runfiles/with\nnewline\\and backslash")
+                     ("source with space,\nnewline,\\and backslash"
+                      "/:/runfiles/with space,\nnewline,\\and backslash")))
+      (ert-info (source :prefix "Source: ")
+        (should (equal (elisp/runfiles/rlocation source runfiles) target))))))
 
 (ert-deftest elisp/runfiles/make/empty-file ()
   (let* ((manifest (elisp/runfiles/rlocation

--- a/elisp/runfiles/test-manifest
+++ b/elisp/runfiles/test-manifest
@@ -1,3 +1,6 @@
 __init__.py 
 foo/bar runfiles/foo/bar
 testäα𝐴🐈'.txt /runfiles/testäα𝐴🐈'.txt
+target-with-space /runfiles/with space\and backslash
+ target-with-newline /runfiles/with\nnewline\band backslash
+ source\swith\sspace,\nnewline,\band\sbackslash /runfiles/with space,\nnewline,\band backslash


### PR DESCRIPTION
Bazel supports them with https://github.com/bazelbuild/bazel/pull/23331.

Step 2: support them for manifest-based runfiles.