### PR TITLE
Update to rules_go v0.50.1.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,7 +27,7 @@ bazel_dep(name = "protobuf", version = "28.2", repo_name = "com_google_protobuf"
 
 # Development-only module dependencies
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "rules_go", version = "0.48.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.50.1", dev_dependency = True, repo_name = "io_bazel_rules_go")
 bazel_dep(name = "abseil-py", version = "1.4.0", dev_dependency = True, repo_name = "io_abseil_py")
 bazel_dep(name = "gazelle", version = "0.39.1", dev_dependency = True, repo_name = "bazel_gazelle")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -100,7 +100,6 @@
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
-    "https://bcr.bazel.build/modules/rules_go/0.48.0/MODULE.bazel": "d00ebcae0908ee3f5e6d53f68677a303d6d59a77beef879598700049c3980a03",
     "https://bcr.bazel.build/modules/rules_go/0.50.1/MODULE.bazel": "b91a308dc5782bb0a8021ad4330c81fea5bda77f96b9e4c117b9b9c8f6665ee0",
     "https://bcr.bazel.build/modules/rules_go/0.50.1/source.json": "205765fd30216c70321f84c9a967267684bdc74350af3f3c46c857d9f80a4fa2",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,10 +120,10 @@ non_module_dev_deps(name = "phst_rules_elisp_dev_deps")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "33acc4ae0f70502db4b893c9fc1dd7a9bf998c23e7ff2c4517741d4049a976f8",
+    sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
     ],
 )
 
@@ -133,7 +133,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//dev:nogo",
-    version = "1.22.0",
+    version = "1.23.0",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_go/releases/tag/v0.50.1.