### PR TITLE
Remove -undefined dynamic_lookup workaround.

### DIFF
--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -31,7 +31,6 @@ load(
     "LINKOPTS",
     "MAX_MANUAL_ADDITIONAL_INPUTS",
     "PACKAGE_FEATURES",
-    "UNDEFINED_ERROR",
     "bootstrap",
     "cc_defaults",
     "executable_only",
@@ -525,7 +524,7 @@ module_config(
             "-Wl,-exported_symbol,_emacs_module_init",
             "-Wl,-exported_symbol,_plugin_is_GPL_compatible",
         ],
-    }) + UNDEFINED_ERROR,
+    }),
     suffix = select({
         "@platforms//os:linux": ".so",
         "@platforms//os:windows": ".dll",

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -16,7 +16,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain_suite")
 load("@rules_python//python:defs.bzl", "py_binary", "py_test")
-load("//private:defs.bzl", "PACKAGE_FEATURES", "UNDEFINED_ERROR", "cc_defaults")
+load("//private:defs.bzl", "PACKAGE_FEATURES", "cc_defaults")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -163,10 +163,7 @@ cc_defaults(
         # Don’t link against the C++ standard library, as Emacs is pure C code.
         "-default_link_libs",
     ],
-    # On macOS, override the toolchain’s “-undefined dynamic_lookup” option so
-    # that the configure script doesn’t incorrectly detect absent functions as
-    # present.
-    linkopts = UNDEFINED_ERROR,
+    linkopts = [],
     visibility = [
         # FIXME: Make private once
         # https://github.com/bazelbuild/proposals/blob/main/designs/2019-10-15-tool-visibility.md

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -710,14 +710,6 @@ LAUNCHER_DEPS = [
     Label("@com_google_absl//absl/types:span"),
 ]
 
-# Pass “-undefined error” to the linker to find undefined symbols at link time.
-# Do that only if the toolchain passes “-undefined dynamic_lookup” to avoid a
-# warning on newer macOS versions.
-UNDEFINED_ERROR = select({
-    Label("@platforms//os:macos"): ["-undefined", "error"] if bazel_features.cc.undefined_dynamic_lookup else [],
-    Label("//conditions:default"): [],
-})
-
 # FIXME: This restriction is arbitrary; elisp_binary rules should accept any
 # number of input files if necessary.
 MAX_MANUAL_ADDITIONAL_INPUTS = 10


### PR DESCRIPTION
Neither rules_cc nor bazel_tools from any supported Bazel version pass -undefined dynamic_lookup any more.