### PR TITLE
Don’t load ‘interpreter’ symbol from Python toolchain.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,12 +52,11 @@ python_register_toolchains(
     register_coverage_tool = True,
 )
 
-load("@hermetic_python//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
     name = "pip_deps",
-    python_interpreter_target = interpreter,
+    python_interpreter_target = "@hermetic_python_host//:python",
     requirements_darwin = "//dev:macos-requirements.txt",
     requirements_linux = "//dev:linux-requirements.txt",
     requirements_lock = None,


### PR DESCRIPTION
This symbol was removed in
https://github.com/bazelbuild/rules_python/commit/68d1b4104f1d6f72ed0f3a8a5bf0a75d94cb74ec. See
https://rules-python.readthedocs.io/en/latest/getting-started.html#using-a-workspace-file for the documented alternative.