### PR TITLE
Treat external repositories as system headers for warning purposes.

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -20,6 +20,7 @@ repo(
         "no_copts_tokenization",
         "layering_check",
         "parse_headers",
+        "external_include_paths",
         # On Windows, Bazel generates incorrectly-escaped parameter files.  See
         # https://github.com/bazelbuild/bazel/issues/21029.
         "-compiler_param_file",

--- a/examples/ext/REPO.bazel
+++ b/examples/ext/REPO.bazel
@@ -20,6 +20,7 @@ repo(
         "no_copts_tokenization",
         "layering_check",
         "parse_headers",
+        "external_include_paths",
         # On Windows, Bazel generates incorrectly-escaped parameter files.  See
         # https://github.com/bazelbuild/bazel/issues/21029.
         "-compiler_param_file",

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -411,6 +411,7 @@ PACKAGE_FEATURES = [
     "no_copts_tokenization",
     "layering_check",
     "parse_headers",
+    "external_include_paths",
     # On Windows, Bazel generates incorrectly-escaped parameter files.  See
     # https://github.com/bazelbuild/bazel/issues/21029.
     "-compiler_param_file",


### PR DESCRIPTION
This should reduce the noise necessary to disable warnings.