### PR TITLE
Register local C/C++ toolchain from rules_cc.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ bazel_dep(name = "gazelle", version = "0.39.1", dev_dependency = True, repo_name
 # Bring in the local_config_cc repository.  It’s needed for
 # //emacs:windows_cc_toolchain.
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
-use_repo(cc_configure, "local_config_cc")
+use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")
 
 # Non-module dependencies
 deps = use_extension("//private:extensions.bzl", "deps")
@@ -53,6 +53,9 @@ use_repo(dev_deps, "phst_rules_elisp_dev_deps")
 
 # Local toolchains
 register_toolchains("@phst_rules_elisp//elisp:hermetic_toolchain")
+
+# C++-specific dependencies
+register_toolchains("@local_config_cc_toolchains//:all")
 
 # Python-specific dependencies
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,6 +38,12 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+
+rules_cc_dependencies()
+
+rules_cc_toolchains()
+
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
 py_repositories()

--- a/docs/manual.org
+++ b/docs/manual.org
@@ -95,6 +95,12 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+
+rules_cc_dependencies()
+
+rules_cc_toolchains()
+
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()

--- a/examples/ext/WORKSPACE
+++ b/examples/ext/WORKSPACE
@@ -35,6 +35,12 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+
+rules_cc_dependencies()
+
+rules_cc_toolchains()
+
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()


### PR DESCRIPTION
This means that we benefit from toolchain improvements in rules_cc, independent of the Bazel version.