### PR TITLE
Remove unnecessary http_archive stanza.

### DIFF
--- a/examples/ext/WORKSPACE
+++ b/examples/ext/WORKSPACE
@@ -39,15 +39,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "rules_python",
-    sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b",
-    strip_prefix = "rules_python-0.26.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.26.0/rules_python-0.26.0.tar.gz",
-)
-
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()


### PR DESCRIPTION
rules_elisp_dependencies already brings in an up-to-date version of rules_python.