### PR TITLE
Enable treat_warnings_as_errors feature unconditionally.

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -16,6 +16,7 @@ repo(
     default_applicable_licenses = [":license"],
     default_visibility = ["//visibility:private"],
     features = [
+        "treat_warnings_as_errors",
         "no_copts_tokenization",
         "layering_check",
         "parse_headers",

--- a/examples/ext/REPO.bazel
+++ b/examples/ext/REPO.bazel
@@ -16,6 +16,7 @@ repo(
     default_applicable_licenses = ["@phst_rules_elisp//:license"],
     default_visibility = ["//visibility:private"],
     features = [
+        "treat_warnings_as_errors",
         "no_copts_tokenization",
         "layering_check",
         "parse_headers",

--- a/private/BUILD
+++ b/private/BUILD
@@ -36,7 +36,6 @@ bzl_library(
     ],
     deps = [
         ":generated",
-        "@bazel_features//:features",
         "@bazel_skylib//lib:paths",
         "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -16,7 +16,6 @@
 
 These definitions are internal and subject to change without notice."""
 
-load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
@@ -404,16 +403,11 @@ def run_emacs(
         toolchain = Label("//elisp:toolchain_type"),
     )
 
-# We can’t use treat_warnings_as_errors on macOS unconditionally yet because
-# it tries to pass a flag -fatal-warnings to the linker, but the macOS
-# linker accepts -fatal_warnings instead.  See
-# https://github.com/bazelbuild/bazel/issues/20919.
-_WARNINGS_AS_ERRORS = [("" if bazel_features.cc.treat_warnings_as_errors_works_on_macos else "-") + "treat_warnings_as_errors"]
-
 # Features for all packages.  These may not contain select expressions.
 # FIXME: Once we drop support for Bazel 7.0, move these features to the
 # REPO.bazel files, and remove them from BUILD files.
 PACKAGE_FEATURES = [
+    "treat_warnings_as_errors",
     "no_copts_tokenization",
     "layering_check",
     "parse_headers",
@@ -421,13 +415,9 @@ PACKAGE_FEATURES = [
     # https://github.com/bazelbuild/bazel/issues/21029.
     "-compiler_param_file",
     "-macos_default_link_flags",
-] + _WARNINGS_AS_ERRORS
+]
 
-FEATURES = select({
-    Label("@platforms//os:macos"): _WARNINGS_AS_ERRORS,
-    Label("//conditions:default"): ["treat_warnings_as_errors"],
-})
-
+FEATURES = []
 LAUNCHER_FEATURES = FEATURES
 
 # Shared C++ compilation options.


### PR DESCRIPTION
We now use the toolchain configuration from rules_cc, which has the fix to https://github.com/bazelbuild/bazel/issues/20919, independent of the Bazel version.