### PR TITLE
Visual C++: lower external warning level to 2.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,7 +24,7 @@ build --host_features=external_include_paths
 
 # The next line shouldn’t be necessary.
 # TODO: File bug against rules_cc.
-build:windows --copt='/external:W3' --host_copt='/external:W3'
+build:windows --copt='/external:W2' --host_copt='/external:W2'
 
 # Run Pylint by default.
 build --aspects='//private:defs.bzl%check_python'

--- a/elisp/binary.cc
+++ b/elisp/binary.cc
@@ -24,7 +24,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"

--- a/elisp/binary.h
+++ b/elisp/binary.h
@@ -29,7 +29,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"

--- a/elisp/emacs.cc
+++ b/elisp/emacs.cc
@@ -24,7 +24,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"

--- a/elisp/emacs.h
+++ b/elisp/emacs.h
@@ -29,7 +29,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"

--- a/elisp/launcher.cc
+++ b/elisp/launcher.cc
@@ -22,7 +22,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/container/fixed_array.h"
 #include "absl/log/log.h"

--- a/elisp/process.cc
+++ b/elisp/process.cc
@@ -60,7 +60,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/algorithm/container.h"
 #include "absl/base/attributes.h"

--- a/elisp/process.h
+++ b/elisp/process.h
@@ -30,7 +30,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"

--- a/elisp/proto/module.c
+++ b/elisp/proto/module.c
@@ -110,7 +110,7 @@
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  ifdef _MSC_VER
-#    pragma warning(push, 3)
+#    pragma warning(push, 2)
 #    pragma warning(disable : 5105)
 #  endif
 #  include <windows.h>
@@ -186,7 +186,7 @@ enum { kMaxIO = 0x7FFFF000 };
 #  pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #  pragma warning(disable : 4090 4098 4244 4267 4334)
 #endif
 #include "absl/base/attributes.h"

--- a/elisp/test.cc
+++ b/elisp/test.cc
@@ -24,7 +24,7 @@
 #  pragma GCC diagnostic ignored "-Woverflow"
 #endif
 #ifdef _MSC_VER
-#  pragma warning(push, 3)
+#  pragma warning(push, 2)
 #endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -429,7 +429,7 @@ COPTS = select({
         "/utf-8",
         "/permissive-",
         "/Zc:__cplusplus",
-        "/external:W3",  # TODO: shouldn’t be needed; file bug against rules_cc
+        "/external:W2",  # TODO: shouldn’t be needed; file bug against rules_cc
     ],
     Label("//private:gcc_or_clang"): [
         "-finput-charset=utf-8",


### PR DESCRIPTION
Otherwise newer versions of Abseil fail to compile.