### PR TITLE
Don’t rename repositories in MODULE.bazel.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,4 @@
-;; Copyright 2021, 2022, 2023 Google LLC
+;; Copyright 2021, 2022, 2023, 2025 Google LLC
 ;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
  (c-mode . ((page-delimiter . "^///")
             (mode . subword)))
  (js-json-mode . ((js-indent-level . 2)))
- ("elisp/proto/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../../" "../../bazel-bin/" "../../bazel-bin/external/com_google_protobuf/")))))
+ ("elisp/proto/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../../" "../../bazel-bin/" "../../bazel-bin/external/protobuf/")))))
  ("elisp/runfiles/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../../")))))
- ("examples/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../" "./" "ext/" "../bazel-bin/" "../bazel-bin/external/com_google_protobuf/")))))
+ ("examples/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../" "./" "ext/" "../bazel-bin/" "../bazel-bin/external/protobuf/")))))
  ("tests/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../")))))
  ("tests/pkg/" . ((emacs-lisp-mode . ((elisp-flymake-byte-compile-load-path "../../"))))))

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,14 +25,14 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.1.0")
 bazel_dep(name = "rules_python", version = "1.0.0")
-bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2", repo_name = "com_google_absl")
-bazel_dep(name = "protobuf", version = "29.2", repo_name = "com_google_protobuf")
+bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2")
+bazel_dep(name = "protobuf", version = "29.2")
 
 # Development-only module dependencies
-bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "rules_go", version = "0.51.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
-bazel_dep(name = "abseil-py", version = "2.1.0", dev_dependency = True, repo_name = "io_abseil_py")
-bazel_dep(name = "gazelle", version = "0.40.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.51.0", dev_dependency = True)
+bazel_dep(name = "abseil-py", version = "2.1.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.40.0", dev_dependency = True)
 
 # Bring in the local_config_cc repository.  It’s needed for
 # //emacs:windows_cc_toolchain.
@@ -79,10 +79,10 @@ pip.parse(
 use_repo(pip, pip_deps = "pip")
 
 # Go-specific dependencies
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
 go_sdk.nogo(nogo = "//dev:nogo")
 
-go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
 go_deps.module(
     path = "github.com/bazelbuild/buildtools",
     sum = "h1:FGzENZi+SX9I7h9xvMtRA3rel8hCEfyzSixteBgn7MU=",
@@ -141,7 +141,7 @@ archive_override(
 
 # We want to test the external example without adding its repository to the
 # registry.  So we override the dependency immediately locally.
-bazel_dep(name = "phst_rules_elisp_example", dev_dependency = True, repo_name = "example")
+bazel_dep(name = "phst_rules_elisp_example", dev_dependency = True)
 local_path_override(
     module_name = "phst_rules_elisp_example",
     path = "examples/ext",

--- a/build.py
+++ b/build.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ class Builder:
                 for file in filenames:
                     file = pathlib.Path(dirpath) / file
                     text = file.read_text(encoding='utf-8')
-                    if '@io_bazel_rules_go' in text:
+                    if '@rules_go' in text:
                         raise ValueError(f'unwanted Go targets in {file} found')
 
     @target

--- a/dev/BUILD
+++ b/dev/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@gazelle//:def.bzl", "gazelle")
 load("@hermetic_python//:defs.bzl", "compile_pip_requirements", "py_binary")
-load("@io_bazel_rules_go//go:def.bzl", "TOOLS_NOGO", "go_test", "nogo")
 load("@pip_deps//:requirements.bzl", "requirement")
+load("@rules_go//go:def.bzl", "TOOLS_NOGO", "go_test", "nogo")
 load("//private:defs.bzl", "PACKAGE_FEATURES")
 
 package(

--- a/dev/gopackagesdriver
+++ b/dev/gopackagesdriver
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 Philipp Stephani
+# Copyright 2024, 2025 Philipp Stephani
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 set -efuC
 
 # See https://github.com/bazelbuild/rules_go/wiki/Editor-setup#2-launcher-script
-exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "$@"
+exec bazel run -- @rules_go//go/tools/gopackagesdriver "$@"

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@pip_deps//:requirements.bzl", "requirement")
+load("@protobuf//bazel:py_proto_library.bzl", "py_proto_library")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 load("//elisp:defs.bzl", "elisp_binary", "elisp_manual")
 load("//private:defs.bzl", "PACKAGE_FEATURES", "merged_manual")
 
@@ -73,8 +73,8 @@ stardoc(
         "//private:defs",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:paths",
-        "@com_google_protobuf//bazel/common:proto_common_bzl",
-        "@com_google_protobuf//bazel/common:proto_info_bzl",
+        "@protobuf//bazel/common:proto_common_bzl",
+        "@protobuf//bazel/common:proto_info_bzl",
         "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",
     ],
@@ -116,5 +116,5 @@ py_binary(
 py_proto_library(
     name = "stardoc_output_py_proto",
     tags = ["no-python-check"],
-    deps = ["@io_bazel_stardoc//stardoc/proto:stardoc_output_proto"],
+    deps = ["@stardoc//stardoc/proto:stardoc_output_proto"],
 )

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -108,8 +108,8 @@ bzl_library(
         "//private:defs",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:paths",
-        "@com_google_protobuf//bazel/common:proto_common_bzl",
-        "@com_google_protobuf//bazel/common:proto_info_bzl",
+        "@protobuf//bazel/common:proto_common_bzl",
+        "@protobuf//bazel/common:proto_info_bzl",
         "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",
     ],
@@ -165,9 +165,9 @@ cc_library(
     deps = [
         ":platform",
         ":process",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/types:span",
         "@bazel_tools//tools/cpp/runfiles",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -192,9 +192,9 @@ cc_library(
     deps = [
         ":platform",
         ":process",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/types:span",
         "@bazel_tools//tools/cpp/runfiles",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -217,8 +217,8 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":runfiles",
-        "@io_abseil_py//absl/flags",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/flags",
+        "@abseil-py//absl/testing:absltest",
     ],
 )
 
@@ -285,9 +285,9 @@ cc_library(
     deps = [
         ":platform",
         ":process",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/types:span",
         "@bazel_tools//tools/cpp/runfiles",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -324,7 +324,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":manifest",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/testing:absltest",
     ],
 )
 
@@ -344,7 +344,7 @@ py_test(
     deps = [
         ":load",
         ":runfiles",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/testing:absltest",
     ],
 )
 
@@ -373,20 +373,20 @@ cc_library(
     local_defines = DEFINES,
     deps = [
         ":platform",
+        "@abseil-cpp//absl/algorithm:container",
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/base:nullability",
+        "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/log:check",
+        "@abseil-cpp//absl/log:die_if_null",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/types:span",
         "@bazel_tools//tools/cpp/runfiles",
-        "@com_google_absl//absl/algorithm:container",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/base:nullability",
-        "@com_google_absl//absl/cleanup",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/hash",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/log:check",
-        "@com_google_absl//absl/log:die_if_null",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/elisp/defs.bzl
+++ b/elisp/defs.bzl
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
-load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
+load("@protobuf//bazel/common:proto_common.bzl", "proto_common")
+load("@protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")

--- a/elisp/proto/BUILD
+++ b/elisp/proto/BUILD
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@com_google_protobuf//bazel:upb_c_proto_library.bzl", "upb_c_proto_library")
-load("@com_google_protobuf//bazel:upb_proto_reflection_library.bzl", "upb_proto_reflection_library")
-load("@com_google_protobuf//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@protobuf//bazel:upb_c_proto_library.bzl", "upb_c_proto_library")
+load("@protobuf//bazel:upb_proto_reflection_library.bzl", "upb_proto_reflection_library")
+load("@protobuf//bazel/toolchains:proto_lang_toolchain.bzl", "proto_lang_toolchain")
 load("@rules_python//python:defs.bzl", "py_test")
 load("//elisp:defs.bzl", "elisp_binary", "elisp_cc_module", "elisp_library", "elisp_proto_library", "elisp_test")
 load("//private:defs.bzl", "CONLYOPTS", "COPTS", "DEFINES", "FEATURES", "PACKAGE_FEATURES")
@@ -54,77 +54,77 @@ elisp_test(
     ],
 )
 
-# Well-known protocol buffers.  See @com_google_protobuf//:BUILD.
+# Well-known protocol buffers.  See @protobuf//:BUILD.
 elisp_proto_library(
     name = "any_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:any_proto"],
+    deps = ["@protobuf//:any_proto"],
 )
 
 elisp_proto_library(
     name = "api_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:api_proto"],
+    deps = ["@protobuf//:api_proto"],
 )
 
 elisp_proto_library(
     name = "compiler_plugin_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:compiler_plugin_proto"],
+    deps = ["@protobuf//:compiler_plugin_proto"],
 )
 
 elisp_proto_library(
     name = "descriptor_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:descriptor_proto"],
+    deps = ["@protobuf//:descriptor_proto"],
 )
 
 elisp_proto_library(
     name = "duration_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:duration_proto"],
+    deps = ["@protobuf//:duration_proto"],
 )
 
 elisp_proto_library(
     name = "empty_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:empty_proto"],
+    deps = ["@protobuf//:empty_proto"],
 )
 
 elisp_proto_library(
     name = "field_mask_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:field_mask_proto"],
+    deps = ["@protobuf//:field_mask_proto"],
 )
 
 elisp_proto_library(
     name = "source_context_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:source_context_proto"],
+    deps = ["@protobuf//:source_context_proto"],
 )
 
 elisp_proto_library(
     name = "struct_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:struct_proto"],
+    deps = ["@protobuf//:struct_proto"],
 )
 
 elisp_proto_library(
     name = "timestamp_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:timestamp_proto"],
+    deps = ["@protobuf//:timestamp_proto"],
 )
 
 elisp_proto_library(
     name = "type_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:type_proto"],
+    deps = ["@protobuf//:type_proto"],
 )
 
 elisp_proto_library(
     name = "wrappers_elisp_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_google_protobuf//:wrappers_proto"],
+    deps = ["@protobuf//:wrappers_proto"],
 )
 
 proto_lang_toolchain(
@@ -158,17 +158,17 @@ elisp_cc_module(
         ":timestamp_upb_c_proto",
         ":timestamp_upb_proto_reflection",
         "//emacs:module_header",
-        "@com_google_absl//absl/base:config",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_protobuf//upb/base",
-        "@com_google_protobuf//upb/json",
-        "@com_google_protobuf//upb/mem",
-        "@com_google_protobuf//upb/message",
-        "@com_google_protobuf//upb/message:types",
-        "@com_google_protobuf//upb/reflection",
-        "@com_google_protobuf//upb/text",
-        "@com_google_protobuf//upb/util:required_fields",
-        "@com_google_protobuf//upb/wire",
+        "@abseil-cpp//absl/base:config",
+        "@abseil-cpp//absl/base:core_headers",
+        "@protobuf//upb/base",
+        "@protobuf//upb/json",
+        "@protobuf//upb/mem",
+        "@protobuf//upb/message",
+        "@protobuf//upb/message:types",
+        "@protobuf//upb/reflection",
+        "@protobuf//upb/text",
+        "@protobuf//upb/util:required_fields",
+        "@protobuf//upb/wire",
     ],
 )
 
@@ -185,8 +185,8 @@ py_test(
     srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
-        "@io_abseil_py//absl/flags",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/flags",
+        "@abseil-py//absl/testing:absltest",
     ],
 )
 
@@ -214,42 +214,42 @@ elisp_binary(
 
 upb_c_proto_library(
     name = "descriptor_upb_c_proto",
-    deps = ["@com_google_protobuf//:descriptor_proto"],
+    deps = ["@protobuf//:descriptor_proto"],
 )
 
 upb_c_proto_library(
     name = "any_upb_c_proto",
-    deps = ["@com_google_protobuf//:any_proto"],
+    deps = ["@protobuf//:any_proto"],
 )
 
 upb_proto_reflection_library(
     name = "any_upb_proto_reflection",
-    deps = ["@com_google_protobuf//:any_proto"],
+    deps = ["@protobuf//:any_proto"],
 )
 
 upb_c_proto_library(
     name = "duration_upb_c_proto",
-    deps = ["@com_google_protobuf//:duration_proto"],
+    deps = ["@protobuf//:duration_proto"],
 )
 
 upb_proto_reflection_library(
     name = "duration_upb_proto_reflection",
-    deps = ["@com_google_protobuf//:duration_proto"],
+    deps = ["@protobuf//:duration_proto"],
 )
 
 upb_c_proto_library(
     name = "timestamp_upb_c_proto",
-    deps = ["@com_google_protobuf//:timestamp_proto"],
+    deps = ["@protobuf//:timestamp_proto"],
 )
 
 upb_proto_reflection_library(
     name = "timestamp_upb_proto_reflection",
-    deps = ["@com_google_protobuf//:timestamp_proto"],
+    deps = ["@protobuf//:timestamp_proto"],
 )
 
 upb_c_proto_library(
     name = "compiler_plugin_upb_c_proto",
-    deps = ["@com_google_protobuf//:compiler_plugin_proto"],
+    deps = ["@protobuf//:compiler_plugin_proto"],
 )
 
 proto_library(

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -46,8 +46,8 @@ py_test(
     srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
-        "@io_abseil_py//absl/flags",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/flags",
+        "@abseil-py//absl/testing:absltest",
     ],
 )
 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_python//python:defs.bzl", "py_test")
 load(
     "//elisp:defs.bzl",
@@ -42,7 +42,7 @@ elisp_library(
     deps = [
         ":lib_2",
         "//elisp/runfiles",
-        "@example//:lib_4",
+        "@phst_rules_elisp_example//:lib_4",
     ],
 )
 
@@ -129,8 +129,8 @@ py_test(
     srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
-        "@io_abseil_py//absl/flags",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/flags",
+        "@abseil-py//absl/testing:absltest",
     ],
 )
 

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@gazelle//:def.bzl", "gazelle_binary")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//private:defs.bzl", "PACKAGE_FEATURES")
 
 package(
@@ -46,13 +46,13 @@ go_library(
     importpath = "github.com/phst/rules_elisp/gazelle",
     visibility = ["//visibility:private"],
     deps = [
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//pathtools:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
+        "@gazelle//config:go_default_library",
+        "@gazelle//label:go_default_library",
+        "@gazelle//language:go_default_library",
+        "@gazelle//pathtools:go_default_library",
+        "@gazelle//repo:go_default_library",
+        "@gazelle//resolve:go_default_library",
+        "@gazelle//rule:go_default_library",
     ],
 )
 
@@ -69,15 +69,15 @@ go_test(
     rundir = ".",
     deps = [
         ":go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
-        "@bazel_gazelle//testtools:go_default_library",
         "@com_github_bazelbuild_buildtools//build:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@io_bazel_rules_go//go/runfiles",
+        "@gazelle//label:go_default_library",
+        "@gazelle//language:go_default_library",
+        "@gazelle//repo:go_default_library",
+        "@gazelle//resolve:go_default_library",
+        "@gazelle//rule:go_default_library",
+        "@gazelle//testtools:go_default_library",
+        "@rules_go//go/runfiles",
     ],
 )
 

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -699,12 +699,12 @@ LAUNCHER_ATTRS = {
 
 LAUNCHER_DEPS = [
     Label("//elisp:platform"),
-    Label("@com_google_absl//absl/container:fixed_array"),
-    Label("@com_google_absl//absl/log"),
-    Label("@com_google_absl//absl/meta:type_traits"),
-    Label("@com_google_absl//absl/status"),
-    Label("@com_google_absl//absl/status:statusor"),
-    Label("@com_google_absl//absl/types:span"),
+    Label("@abseil-cpp//absl/container:fixed_array"),
+    Label("@abseil-cpp//absl/log"),
+    Label("@abseil-cpp//absl/meta:type_traits"),
+    Label("@abseil-cpp//absl/status"),
+    Label("@abseil-cpp//absl/status:statusor"),
+    Label("@abseil-cpp//absl/types:span"),
 ]
 
 # FIXME: This restriction is arbitrary; elisp_binary rules should accept any

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@rules_go//go:def.bzl", "go_test")
 load("@rules_python//python:defs.bzl", "py_test")
 load("//elisp:defs.bzl", "elisp_binary", "elisp_library", "elisp_test")
 load("//private:defs.bzl", "PACKAGE_FEATURES")
@@ -58,7 +58,7 @@ go_test(
     deps = [
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
-        "@io_bazel_rules_go//go/runfiles",
+        "@rules_go//go/runfiles",
     ],
 )
 
@@ -134,7 +134,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
-        "@io_abseil_py//absl/flags",
-        "@io_abseil_py//absl/testing:absltest",
+        "@abseil-py//absl/flags",
+        "@abseil-py//absl/testing:absltest",
     ],
 )


### PR DESCRIPTION
The renaming was only necessary for compatibility with WORKSPACE-only builds.