### PR TITLE
Set lockfile mode in setup action.

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -71,10 +71,15 @@ runs:
       shell: bash
       run: |
         set -euxC
+        # The lockfile format differs between the Bazel versions, so only for
+        # one version --lockfile_mode=error can work.  --lockfile_mode=update
+        # would be useless since we never use the updated lockfiles, so switch
+        # lockfiles off entirely in other Bazel versions.
         cat >> github.bazelrc <<'EOF'
         common --announce_rc
         common --show_progress_rate_limit=10
         common --remote_download_minimal
+        common --lockfile_mode=${{inputs.bazel-version == 'latest' && 'error' || 'off'}}
         build --verbose_failures
         build --experimental_convenience_symlinks=ignore
         build --show_result=0

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -57,16 +57,6 @@ jobs:
           bazel-version: ${{matrix.bazel}}
           cc: ${{matrix.cc}}
           github-token: ${{secrets.GITHUB_TOKEN}}
-      - name: Set lockfile mode
-        # The lockfile format differs between the Bazel versions, so only for
-        # one version --lockfile_mode=error can work.  --lockfile_mode=update
-        # would be useless since we never use the updated lockfiles, so switch
-        # lockfiles off entirely in other Bazel versions.
-        shell: bash
-        run: >-
-          echo common
-          --lockfile_mode=${{matrix.bazel == 'latest' && 'error' || 'off'}}>>
-          github.bazelrc
       - name: Run Bazel tests
         shell: pwsh
         run: python build.py --profiles='${{runner.temp}}/profiles' -- check


### PR DESCRIPTION
Workflows that want a different lockfile mode already override it on the command line.