### PR TITLE
Revert "Read another .bazelrc file github.bazelrc if it exists."

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,5 +31,3 @@ build --aspects='//private:defs.bzl%check_python'
 build --output_groups='+check_python'
 
 import %workspace%/c-std.bazelrc
-
-try-import %workspace%/github.bazelrc

--- a/examples/ext/.bazelrc
+++ b/examples/ext/.bazelrc
@@ -1,4 +1,4 @@
-# Copyright 2023, 2024 Google LLC
+# Copyright 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,3 @@
 # limitations under the License.
 
 import %workspace%/../../c-std.bazelrc
-
-try-import %workspace%/../../github.bazelrc


### PR DESCRIPTION
This reverts commit d03524ae8566e22c1043fe82deda1c3a8bd725eb.

We don't write anything to github.bazelrc any longer.