### PR TITLE
Remove BAZELISK_GITHUB_TOKEN environment variable.

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -19,9 +19,6 @@ inputs:
   bazel-version:
     description: Bazel version to use
     required: true
-  github-token:
-    description: GitHub authentication token from secrets.GITHUB_TOKEN
-    required: true
   cc:
     description: C/C++ compiler to use
     required: false
@@ -86,9 +83,6 @@ runs:
       shell: bash
       run: |
         set -euxC
-        # BAZELISK_GITHUB_TOKEN: See
-        # https://github.com/bazelbuild/bazelisk/issues/88#issuecomment-625178467.
-        #
         # BAZEL_USE_CPP_ONLY_TOOLCHAIN: We don’t need XCode, and using the Unix
         # toolchain tends to be less flaky.  See
         # https://github.com/bazelbuild/bazel/issues/14113#issuecomment-999794586.
@@ -96,7 +90,6 @@ runs:
         # locally; see https://github.com/bazelbuild/bazel/issues/14970.
         cat >> "${GITHUB_ENV:?}" <<'EOF'
         USE_BAZEL_VERSION=${{inputs.bazel-version}}
-        BAZELISK_GITHUB_TOKEN=${{inputs.github-token}}
         BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
         CC=${{inputs.cc}}
         EOF

--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -56,7 +56,6 @@ jobs:
         with:
           bazel-version: ${{matrix.bazel}}
           cc: ${{matrix.cc}}
-          github-token: ${{secrets.GITHUB_TOKEN}}
       - name: Run Bazel tests
         shell: pwsh
         run: python build.py --profiles='${{runner.temp}}/profiles' -- check

--- a/.github/workflows/debug-cache.yaml
+++ b/.github/workflows/debug-cache.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ jobs:
         uses: ./.github/actions/set-up
         with:
           bazel-version: latest
-          github-token: ${{secrets.GITHUB_TOKEN}}
       - name: Build Emacs
         shell: pwsh
         # We don’t care about lockfiles here.

--- a/.github/workflows/update-lockfiles.yaml
+++ b/.github/workflows/update-lockfiles.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022, 2023, 2024 Google LLC
+# Copyright 2021, 2022, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ jobs:
         uses: ./.github/actions/set-up
         with:
           bazel-version: latest
-          github-token: ${{secrets.GITHUB_TOKEN}}
       - name: Regenerate lockfiles
         shell: pwsh
         run: python build.py -- lock


### PR DESCRIPTION
The setup-bazel action now sets this variable,
cf. https://github.com/bazel-contrib/setup-bazel/issues/57.