### PR TITLE
Put Go dependencies in go.mod.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -88,21 +88,7 @@ go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency 
 go_sdk.nogo(nogo = "//dev:nogo")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
-go_deps.module(
-    path = "github.com/bazelbuild/buildtools",
-    sum = "h1:FGzENZi+SX9I7h9xvMtRA3rel8hCEfyzSixteBgn7MU=",
-    version = "v0.0.0-20240918101019-be1c24cc9a44",
-)
-go_deps.module(
-    path = "github.com/google/addlicense",
-    sum = "h1:jpVf9qPbU8rz5MxKo7d+RMcNHkqxi4YJi/laauX4aAE=",
-    version = "v1.1.1",
-)
-go_deps.module(
-    path = "github.com/google/go-cmp",
-    sum = "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=",
-    version = "v0.6.0",
-)
+go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,
     "com_github_bazelbuild_buildtools",

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,23 @@
+// Copyright 2023, 2024, 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module github.com/phst/rules_elisp
+
+go 1.22.0
+
+require (
+        github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44
+        github.com/google/addlicense v1.1.1
+	github.com/google/go-cmp v0.6.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44 h1:FGzENZi+SX9I7h9xvMtRA3rel8hCEfyzSixteBgn7MU=
+github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
+github.com/google/addlicense v1.1.1 h1:jpVf9qPbU8rz5MxKo7d+RMcNHkqxi4YJi/laauX4aAE=
+github.com/google/addlicense v1.1.1/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
This allows Renovate to update them automatically.