### PR TITLE
Simplify non-module development dependencies using use_repo_rule.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,8 +63,12 @@ use_repo(deps, "gnu_emacs_29.4")
 use_repo(deps, "gnu_emacs_windows_28.2")
 use_repo(deps, "gnu_emacs_windows_29.4")
 
-dev_deps = use_extension("//private:extensions.bzl", "dev_deps", dev_dependency = True)
-use_repo(dev_deps, "phst_rules_elisp_dev_deps")
+dev_deps = use_repo_rule("//private:repositories.bzl", "non_module_dev_deps")
+
+dev_deps(
+    name = "phst_rules_elisp_dev_deps",
+    dev_dependency = True,
+)
 
 # Local toolchains
 register_toolchains("@phst_rules_elisp//elisp:hermetic_toolchain")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -202,7 +202,7 @@
     },
     "//private:extensions.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "v6Vx/2tzeL19juCFeE6ZNuFqBLfgmcRAT9iTjN1HdoY=",
+        "bzlTransitiveDigest": "s8onf69OA0b1EpSNUGyKpP69q+6WCIwyW6xaLT83jzw=",
         "usagesDigest": "ARAKUMjn2lih+tNys5k8lsfdKUhUhcOsMxt0x+Bab/U=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -262,11 +262,6 @@
           }
         },
         "recordedRepoMappingEntries": [
-          [
-            "",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
           [
             "",
             "platforms",

--- a/examples/ext/MODULE.bazel.lock
+++ b/examples/ext/MODULE.bazel.lock
@@ -211,7 +211,7 @@
     },
     "@@phst_rules_elisp+//private:extensions.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "v6Vx/2tzeL19juCFeE6ZNuFqBLfgmcRAT9iTjN1HdoY=",
+        "bzlTransitiveDigest": "s8onf69OA0b1EpSNUGyKpP69q+6WCIwyW6xaLT83jzw=",
         "usagesDigest": "pqVdmfUwoAmog+tBeODqQxV5QWTYPgTDSt5nLTCeR6Q=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -271,11 +271,6 @@
           }
         },
         "recordedRepoMappingEntries": [
-          [
-            "phst_rules_elisp+",
-            "bazel_skylib",
-            "bazel_skylib+"
-          ],
           [
             "phst_rules_elisp+",
             "platforms",

--- a/private/BUILD
+++ b/private/BUILD
@@ -44,9 +44,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "repositories",
+    srcs = ["repositories.bzl"],
+)
+
+bzl_library(
     name = "extensions",
     srcs = ["extensions.bzl"],
-    deps = ["@bazel_skylib//lib:modules"],
 )
 
 bzl_library(

--- a/private/extensions.bzl
+++ b/private/extensions.bzl
@@ -14,31 +14,7 @@
 
 """Non-module dependencies."""
 
-load("@bazel_skylib//lib:modules.bzl", "modules")
-
 visibility("private")
-
-def _non_module_dev_deps_impl(ctx):
-    ctx.download_and_extract(
-        sha256 = "ba809d0fedfb392cc604ad38aff7db7d750b77eaf5fed977a51360fa4a6dffdf",
-        url = [
-            "https://github.com/windyroad/JUnit-Schema/archive/refs/tags/1.0.0.tar.gz",  # 2022-04-09
-        ],
-        stripPrefix = "JUnit-Schema-1.0.0/",
-    )
-    ctx.template(
-        "BUILD.bazel",
-        Label("//:junit_xsd.BUILD"),
-        {
-            '"[tests_pkg]"': repr(str(Label("//tests:__pkg__"))),
-        },
-        executable = False,
-    )
-
-_non_module_dev_deps = repository_rule(
-    doc = """Installs development dependencies that are not available as modules.""",
-    implementation = _non_module_dev_deps_impl,
-)
 
 def _emacs_repository_impl(ctx):
     path = ctx.attr.path
@@ -146,9 +122,6 @@ def _deps_impl(ctx):
         for local_emacs in module.tags.local_emacs:
             _local_emacs_repo(name = local_emacs.name)
 
-def _dev_deps_impl():
-    _non_module_dev_deps(name = "phst_rules_elisp_dev_deps")
-
 deps = module_extension(
     tag_classes = {
         "emacs": _emacs,
@@ -156,4 +129,3 @@ deps = module_extension(
     },
     implementation = _deps_impl,
 )
-dev_deps = modules.as_extension(_dev_deps_impl)

--- a/private/repositories.bzl
+++ b/private/repositories.bzl
@@ -1,0 +1,41 @@
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal-only repository functions.
+
+These definitions are internal and subject to change without notice."""
+
+visibility("private")
+
+def _non_module_dev_deps_impl(ctx):
+    ctx.download_and_extract(
+        sha256 = "ba809d0fedfb392cc604ad38aff7db7d750b77eaf5fed977a51360fa4a6dffdf",
+        url = [
+            "https://github.com/windyroad/JUnit-Schema/archive/refs/tags/1.0.0.tar.gz",  # 2022-04-09
+        ],
+        stripPrefix = "JUnit-Schema-1.0.0/",
+    )
+    ctx.template(
+        "BUILD.bazel",
+        Label("//:junit_xsd.BUILD"),
+        {
+            '"[tests_pkg]"': repr(str(Label("//tests:__pkg__"))),
+        },
+        executable = False,
+    )
+
+non_module_dev_deps = repository_rule(
+    doc = """Installs development dependencies that are not available as modules.""",
+    implementation = _non_module_dev_deps_impl,
+)


### PR DESCRIPTION
This partially reverts commit dd78f7fc19b6a470d8365ab96c4e3e4b8ac9ac52.