### PR TITLE
Remove warning pragmas.

### DIFF
--- a/elisp/binary.cc
+++ b/elisp/binary.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+// Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,24 +16,8 @@
 
 #include <initializer_list>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 #include "elisp/process.h"

--- a/elisp/binary.h
+++ b/elisp/binary.h
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+// Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,24 +21,8 @@
 
 #include <initializer_list>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 

--- a/elisp/emacs.cc
+++ b/elisp/emacs.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+// Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,24 +16,8 @@
 
 #include <string_view>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 #include "elisp/process.h"

--- a/elisp/launcher.cc
+++ b/elisp/launcher.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2024 Google LLC
+// Copyright 2020, 2021, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,28 +14,12 @@
 
 #include <cstdlib>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/container/fixed_array.h"
 #include "absl/log/log.h"
 #include "absl/meta/type_traits.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 

--- a/elisp/process.cc
+++ b/elisp/process.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+// Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,16 +52,6 @@
 #include <utility>
 #include <vector>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/algorithm/container.h"
 #include "absl/base/attributes.h"
 #include "absl/base/nullability.h"
@@ -78,12 +68,6 @@
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
 #include "tools/cpp/runfiles/runfiles.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #ifdef __APPLE__
 #  include <crt_externs.h>  // for _NSGetEnviron

--- a/elisp/process.h
+++ b/elisp/process.h
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+// Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,24 +22,8 @@
 #include <initializer_list>
 #include <string_view>  // IWYU pragma: keep
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 

--- a/elisp/proto/module.c
+++ b/elisp/proto/module.c
@@ -1,4 +1,4 @@
-// Copyright 2022, 2023, 2024 Google LLC
+// Copyright 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,16 +179,6 @@ enum { kMaxIO = 0x7FFFF000 };
 #  error Emacs module header too old
 #endif
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#  pragma warning(disable : 4090 4098 4244 4267 4334)
-#endif
 #include "absl/base/attributes.h"
 #include "absl/base/config.h"
 #include "google/protobuf/any.upb.h"
@@ -215,12 +205,6 @@ enum { kMaxIO = 0x7FFFF000 };
 #include "upb/util/required_fields.h"
 #include "upb/wire/decode.h"
 #include "upb/wire/encode.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 /// Global variables
 

--- a/elisp/test.cc
+++ b/elisp/test.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022, 2023, 2024 Google LLC
+// Copyright 2020, 2021, 2022, 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,24 +16,8 @@
 
 #include <initializer_list>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 #include "elisp/process.h"


### PR DESCRIPTION
They should no longer be necessary now that we use the external_include_paths feature.