### PR TITLE
Run OS-independent checks only interactively and on GNU/Linux.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -59,6 +59,11 @@ jobs:
       - name: Run Bazel tests
         shell: pwsh
         run: python build.py --profiles='${{runner.temp}}/profiles' -- check
+      - name: Run OS-independent checks
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          python build.py -- buildifier nogo license
       - name: Upload profiles
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021, 2023, 2024 Google LLC
+# Copyright 2021, 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ all: generate check
 generate: compdb coverage
 
 check:
-	./build.py -- check
+	./build.py -- check buildifier nogo license
 
 GENERATE_BAZELFLAGS = $(BAZELFLAGS) --lockfile_mode=off
 COMPDB_BAZELFLAGS = $(GENERATE_BAZELFLAGS) --output_groups=-check_python

--- a/build.py
+++ b/build.py
@@ -85,9 +85,6 @@ class Builder:
     @target
     def check(self) -> None:
         """Builds and tests the project."""
-        self.buildifier()
-        self.nogo()
-        self.license()
         # Test both default toolchain and versioned toolchains.
         self.test()
         self.versions()


### PR DESCRIPTION
There’s little point running these static checks on all OSes.