### PR TITLE
Use flag to selectively enable treat_warnings_as_errors.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,4 +35,7 @@ build --output_groups='+check_python'
 build:macos --linkopt='-Wl,-no_warn_duplicate_libraries'
 build:macos --host_linkopt='-Wl,-no_warn_duplicate_libraries'
 
+# Treat warnings as errors, but only for this repository.
+build --//private:treat_warnings_as_errors
+
 import %workspace%/c-std.bazelrc

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -16,7 +16,6 @@ repo(
     default_applicable_licenses = [":license"],
     default_visibility = ["//visibility:private"],
     features = [
-        "treat_warnings_as_errors",
         "no_copts_tokenization",
         "layering_check",
         "parse_headers",

--- a/examples/ext/REPO.bazel
+++ b/examples/ext/REPO.bazel
@@ -16,7 +16,6 @@ repo(
     default_applicable_licenses = ["@phst_rules_elisp//:license"],
     default_visibility = ["//visibility:private"],
     features = [
-        "treat_warnings_as_errors",
         "no_copts_tokenization",
         "layering_check",
         "parse_headers",

--- a/private/BUILD
+++ b/private/BUILD
@@ -14,6 +14,7 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load(":defs.bzl", "PACKAGE_FEATURES")
@@ -111,4 +112,14 @@ config_setting(
         "//elisp/proto:__pkg__",
         "//emacs:__pkg__",
     ],
+)
+
+bool_flag(
+    name = "treat_warnings_as_errors",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "treat_warnings_as_errors_enabled",
+    flag_values = {":treat_warnings_as_errors": "true"},
 )

--- a/private/defs.bzl
+++ b/private/defs.bzl
@@ -412,7 +412,6 @@ def run_emacs(
 # FIXME: Once we drop support for Bazel 7.0, move these features to the
 # REPO.bazel files, and remove them from BUILD files.
 PACKAGE_FEATURES = [
-    "treat_warnings_as_errors",
     "no_copts_tokenization",
     "layering_check",
     "parse_headers",
@@ -423,7 +422,11 @@ PACKAGE_FEATURES = [
     "-macos_default_link_flags",
 ]
 
-FEATURES = []
+FEATURES = select({
+    Label(":treat_warnings_as_errors_enabled"): ["treat_warnings_as_errors"],
+    Label("//conditions:default"): [],
+})
+
 LAUNCHER_FEATURES = FEATURES
 
 # Shared C++ compilation options.


### PR DESCRIPTION
We want to enable treat_warnings_as_errors only if we're building the main repository (to isolate users from warnings), and only for the targets in our repository.  Specifying a private flag in .bazelrc seems to be the simplest way to achieve this.

This partially reverts commit 0ae8e08e15cd61ef6de98f0797b6e51e666ac371.