### PR TITLE
Remove treat_warnings_as_errors feature from Emacs BUILD template.

### DIFF
--- a/private/emacs.BUILD.template
+++ b/private/emacs.BUILD.template
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022, 2024 Google LLC
+# Copyright 2020, 2021, 2022, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package(
     features = [
         "layering_check",
         "parse_headers",
-        "treat_warnings_as_errors",
         # On Windows, Bazel generates incorrectly-escaped parameter files.  See
         # https://github.com/bazelbuild/bazel/issues/21029.
         "-compiler_param_file",


### PR DESCRIPTION
Probably we don’t want this feature there, as it forces fatal warnings on all users of the generated repository, independent of the compiler they use.