### PR TITLE
Remove warning pragmas from elisp/emacs.h.

### DIFF
--- a/elisp/emacs.h
+++ b/elisp/emacs.h
@@ -21,24 +21,8 @@
 
 #include <string_view>
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wpedantic"
-#  pragma GCC diagnostic ignored "-Wconversion"
-#  pragma GCC diagnostic ignored "-Wsign-conversion"
-#  pragma GCC diagnostic ignored "-Woverflow"
-#endif
-#ifdef _MSC_VER
-#  pragma warning(push, 2)
-#endif
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 #include "elisp/platform.h"
 


### PR DESCRIPTION
This was apparently forgotten in commit f2d16b00288615ea97f66f905042a7f397e23953.