### PR TITLE
Remove duplication of Starlark library targets for Stardoc.

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -69,15 +69,7 @@ stardoc(
     out = "elisp.binpb",
     format = "proto",
     input = "//elisp:defs.bzl",
-    deps = [
-        "//private:defs",
-        "@bazel_skylib//lib:collections",
-        "@bazel_skylib//lib:paths",
-        "@protobuf//bazel/common:proto_common_bzl",
-        "@protobuf//bazel/common:proto_info_bzl",
-        "@rules_cc//cc:find_cc_toolchain_bzl",
-        "@rules_cc//cc/common",
-    ],
+    deps = ["//elisp:defs"],
 )
 
 stardoc(
@@ -85,13 +77,7 @@ stardoc(
     out = "emacs.binpb",
     format = "proto",
     input = "//emacs:defs.bzl",
-    deps = [
-        "//private:defs",
-        "@bazel_skylib//lib:paths",
-        "@rules_cc//cc:action_names_bzl",
-        "@rules_cc//cc:find_cc_toolchain_bzl",
-        "@rules_cc//cc/common",
-    ],
+    deps = ["//emacs:defs"],
 )
 
 stardoc(
@@ -99,7 +85,7 @@ stardoc(
     out = "extensions.binpb",
     format = "proto",
     input = "//elisp:extensions.bzl",
-    deps = ["@bazel_skylib//lib:modules"],
+    deps = ["//elisp:extensions"],
 )
 
 py_binary(

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -106,6 +106,7 @@ exports_files(
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
+    visibility = ["//docs:__pkg__"],
     deps = [
         "//private:defs",
         "@bazel_skylib//lib:collections",
@@ -120,6 +121,7 @@ bzl_library(
 bzl_library(
     name = "extensions",
     srcs = ["extensions.bzl"],
+    visibility = ["//docs:__pkg__"],
     deps = ["@bazel_skylib//lib:modules"],
 )
 

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -98,6 +98,7 @@ py_binary(
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
+    visibility = ["//docs:__pkg__"],
     deps = [
         "//private:defs",
         "@bazel_skylib//lib:paths",


### PR DESCRIPTION
It turns out that adding the Starlark library for the file being documented is enough.