### PR TITLE
Remove srcs_version attributes from Python rules.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,7 +36,6 @@ py_binary(
     srcs = ["build.py"],
     main = "build.py",
     python_version = "PY3",
-    srcs_version = "PY3",
 )
 
 exports_files(

--- a/dev/BUILD
+++ b/dev/BUILD
@@ -78,7 +78,6 @@ py_binary(
     srcs = ["check_python.py"],
     main = "check_python.py",
     python_version = "3.12.8",
-    srcs_version = "PY3",
     visibility = ["//private:__pkg__"],
     deps = [requirement("pylint")] + select({
         # Pytype doesn’t work on Windows, so don’t build it when running

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -88,7 +88,6 @@ py_binary(
     name = "generate",
     srcs = ["generate.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
     tags = ["no-pytype"],  # FIXME
     deps = [
         ":stardoc_output_py_proto",

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -219,7 +219,6 @@ py_test(
         ":launcher",
     ],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":runfiles",
         "@abseil-py//absl/flags",
@@ -243,7 +242,6 @@ py_binary(
         "//elisp/runfiles:runfiles.elc",
     ],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = ["//elisp:runfiles"],
 )
 
@@ -251,7 +249,6 @@ py_binary(
     name = "run_binary",
     srcs = ["run_binary.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":load",
         ":manifest",
@@ -301,7 +298,6 @@ py_binary(
     testonly = True,
     srcs = ["run_test.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":load",
         ":manifest",
@@ -318,7 +314,6 @@ executable_only(
 py_library(
     name = "manifest",
     srcs = ["manifest.py"],
-    srcs_version = "PY3",
 )
 
 py_test(
@@ -326,7 +321,6 @@ py_test(
     size = "small",
     srcs = ["manifest_test.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":manifest",
         "@abseil-py//absl/testing:absltest",
@@ -336,7 +330,6 @@ py_test(
 py_library(
     name = "load",
     srcs = ["load.py"],
-    srcs_version = "PY3",
     deps = [":runfiles"],
 )
 
@@ -345,7 +338,6 @@ py_test(
     size = "small",
     srcs = ["load_test.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":load",
         ":runfiles",
@@ -356,7 +348,6 @@ py_test(
 py_library(
     name = "runfiles",
     srcs = ["runfiles.py"],
-    srcs_version = "PY3",
     visibility = [
         "//elisp/proto:__pkg__",
         "//emacs:__pkg__",

--- a/elisp/proto/BUILD
+++ b/elisp/proto/BUILD
@@ -182,7 +182,6 @@ py_test(
     ],
     data = [":cat"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -44,7 +44,6 @@ py_test(
     ],
     data = [":emacs"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",
@@ -92,7 +91,6 @@ py_binary(
     name = "build",
     srcs = ["build.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
 )
 
 bzl_library(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -126,7 +126,6 @@ py_test(
     ],
     data = ["bin"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -131,7 +131,6 @@ py_test(
     ],
     data = [":empty"],
     python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",


### PR DESCRIPTION
According to the documentation they are “Defunct, unused, does nothing”:

https://rules-python.readthedocs.io/en/1.1.0/api/rules_python/python/private/py_library_rule.html#py_library.srcs_version https://rules-python.readthedocs.io/en/1.1.0/api/rules_python/python/private/py_binary_rule.html#py_binary.srcs_version https://rules-python.readthedocs.io/en/1.1.0/api/rules_python/python/private/py_test_rule.html#py_test.srcs_version