### PR TITLE
Remove unused python_version attributes from Python rules.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -35,7 +35,6 @@ py_binary(
     name = "build",
     srcs = ["build.py"],
     main = "build.py",
-    python_version = "PY3",
 )
 
 exports_files(

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -87,7 +87,6 @@ starlark_doc_extract(
 py_binary(
     name = "generate",
     srcs = ["generate.py"],
-    python_version = "PY3",
     tags = ["no-pytype"],  # FIXME
     deps = [
         ":stardoc_output_py_proto",

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -218,7 +218,6 @@ py_test(
         "binary.cc",
         ":launcher",
     ],
-    python_version = "PY3",
     deps = [
         ":runfiles",
         "@abseil-py//absl/flags",
@@ -241,14 +240,12 @@ py_binary(
         ":binary.h",
         "//elisp/runfiles:runfiles.elc",
     ],
-    python_version = "PY3",
     deps = ["//elisp:runfiles"],
 )
 
 py_binary(
     name = "run_binary",
     srcs = ["run_binary.py"],
-    python_version = "PY3",
     deps = [
         ":load",
         ":manifest",
@@ -297,7 +294,6 @@ py_binary(
     name = "run_test",
     testonly = True,
     srcs = ["run_test.py"],
-    python_version = "PY3",
     deps = [
         ":load",
         ":manifest",
@@ -320,7 +316,6 @@ py_test(
     name = "manifest_test",
     size = "small",
     srcs = ["manifest_test.py"],
-    python_version = "PY3",
     deps = [
         ":manifest",
         "@abseil-py//absl/testing:absltest",
@@ -337,7 +332,6 @@ py_test(
     name = "load_test",
     size = "small",
     srcs = ["load_test.py"],
-    python_version = "PY3",
     deps = [
         ":load",
         ":runfiles",

--- a/elisp/proto/BUILD
+++ b/elisp/proto/BUILD
@@ -181,7 +181,6 @@ py_test(
         shell.quote("--cat=$(rlocationpath :cat)"),
     ],
     data = [":cat"],
-    python_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -43,7 +43,6 @@ py_test(
         shell.quote("--emacs=$(rlocationpath :emacs)"),
     ],
     data = [":emacs"],
-    python_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",
@@ -90,7 +89,6 @@ alias(
 py_binary(
     name = "build",
     srcs = ["build.py"],
-    python_version = "PY3",
 )
 
 bzl_library(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -125,7 +125,6 @@ py_test(
         shell.quote("--bin=$(rlocationpath :bin)"),
     ],
     data = ["bin"],
-    python_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -130,7 +130,6 @@ py_test(
         shell.quote("--binary=$(rlocationpath :empty)"),
     ],
     data = [":empty"],
-    python_version = "PY3",
     deps = [
         "//elisp:runfiles",
         "@abseil-py//absl/flags",


### PR DESCRIPTION
According to the documentation, “For backwards compatibility, the values PY2 and PY3 are accepted, but treated as an empty/unspecified value.”

https://rules-python.readthedocs.io/en/1.1.0/api/rules_python/python/private/py_binary_rule.html#py_binary.python_version https://rules-python.readthedocs.io/en/1.1.0/api/rules_python/python/private/py_test_rule.html#py_test.python_version