### PR TITLE
Don’t print unknown directives.

### DIFF
--- a/gazelle/language.go
+++ b/gazelle/language.go
@@ -60,7 +60,6 @@ func (elisp) Configure(c *config.Config, rel string, f *rule.File) {
 		for _, dir := range f.Directives {
 			fun, ok := directives[dir.Key]
 			if !ok {
-				log.Printf("%s: unknown directive %s %s", f.Path, dir.Key, dir.Value)
 				continue
 			}
 			fun(f, dir, ext)


### PR DESCRIPTION
rule.File.Directives contains all directives for all languages.