### PR TITLE
Run Makeinfo through sh_binary wrapper script.

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -15,6 +15,7 @@
 load("@pip//:requirements.bzl", "requirement")
 load("@protobuf//bazel:py_proto_library.bzl", "py_proto_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//elisp:defs.bzl", "elisp_binary", "elisp_manual")
 load("//private:defs.bzl", "PACKAGE_FEATURES", "merged_manual")
 
@@ -32,13 +33,18 @@ elisp_manual(
     out = "manual.texi",
 )
 
-# This rule assumes that Texinfo is installed locally.
 genrule(
     name = "info",
     srcs = ["manual.texi"],
     outs = ["rules_elisp.info"],
-    cmd = "$(execpath @local_texinfo//:makeinfo) --no-split --output=$@ -- $<",
-    tools = ["@local_texinfo//:makeinfo"],
+    cmd = "$(execpath :makeinfo) --no-split --output=$@ -- $<",
+    tools = [":makeinfo"],
+)
+
+# This rule assumes that Texinfo is installed locally.
+sh_binary(
+    name = "makeinfo",
+    srcs = ["makeinfo.sh"],
 )
 
 DOCS = [

--- a/docs/makeinfo.sh
+++ b/docs/makeinfo.sh
@@ -1,0 +1,26 @@
+# Copyright 2025 Philipp Stephani
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo HERE
+
+echo PWD
+pwd
+
+echo ENV
+env
+
+echo "BAZEL_SH=$BAZEL_SH"
+
+
+makeinfo "$@"


### PR DESCRIPTION
On all systems including Windows with MSYS2, makeinfo is an interpreted script. Trying to run it directly won’t work on Windows, so we need to go through some shell that interprets shebang lines.