### PR TITLE
Move public definitions out of elisp/extensions.bzl.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -186,16 +186,16 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "//elisp:extensions.bzl%elisp": {
+    "//elisp/extensions:elisp.bzl%elisp": {
       "general": {
-        "bzlTransitiveDigest": "cBvDLFFnQbEadDiZxWUPlOP/eB4j9ZbjwKKG4v31EV8=",
-        "usagesDigest": "liZMS9ce4oz8dRujaSwrLfy/k+xo9hJ7wigNq+eJYmM=",
+        "bzlTransitiveDigest": "keXnJq03rxZE+i99Dizlz6cTSsttnIgR3nNdSSwFrZg=",
+        "usagesDigest": "dzh9Ut9m42pH4+Q0DEkPKJBrv71oNjdwfGFgXMV9dG0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "dash": {
-            "repoRuleId": "@@//elisp:extensions.bzl%_elisp_http_archive",
+            "repoRuleId": "@@//elisp/extensions:elisp.bzl%_elisp_http_archive",
             "attributes": {
               "urls": [
                 "https://github.com/magnars/dash.el/archive/refs/tags/2.19.1.zip"

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -50,7 +50,7 @@ DOCS = [
     ("elisp", "elisp_manual"),
     ("elisp/common", "elisp_info"),
     ("elisp/toolchains", "elisp_toolchain"),
-    ("elisp", "extensions"),
+    ("elisp/extensions", "elisp"),
     ("emacs", "defs"),
 ]
 

--- a/docs/manual.org
+++ b/docs/manual.org
@@ -682,12 +682,12 @@ from {{{var(array)}}}.  Elements are shifted left to fill in the hole.
 
 #+INCLUDE: elisp/toolchains/elisp_toolchain.org
 
-** Symbols defined in =//elisp:extensions.bzl=
+** Symbols defined in =//elisp/extensions:elisp.bzl=
 :PROPERTIES:
 :ALT_TITLE: Extension Starlark symbols
 :END:
 
-#+INCLUDE: elisp/extensions.org
+#+INCLUDE: elisp/extensions/elisp.org
 
 ** Symbols defined in =//emacs:defs.bzl=
 :PROPERTIES:

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -185,8 +185,7 @@ bzl_library(
 bzl_library(
     name = "extensions",
     srcs = ["extensions.bzl"],
-    visibility = ["//docs:__pkg__"],
-    deps = ["@bazel_skylib//lib:modules"],
+    deps = ["//elisp/extensions:elisp"],
 )
 
 cc_binary(
@@ -463,7 +462,6 @@ exports_files(
         "elisp_library.bzl",
         "elisp_manual.bzl",
         "elisp_test.bzl",
-        "extensions.bzl",
     ],
     visibility = ["//docs:__pkg__"],
 )

--- a/elisp/extensions/BUILD
+++ b/elisp/extensions/BUILD
@@ -1,10 +1,10 @@
-# Copyright 2023, 2024, 2025 Google LLC
+# Copyright 2025 Philipp Stephani
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module extensions for Emacs Lisp."""
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-load("//elisp/extensions:elisp.bzl", _elisp = "elisp")
+bzl_library(
+    name = "elisp",
+    srcs = ["elisp.bzl"],
+    visibility = [
+        "//docs:__pkg__",
+        "//elisp:__pkg__",
+    ],
+    deps = ["@bazel_skylib//lib:modules"],
+)
 
-visibility("public")
-
-elisp = _elisp
+exports_files(
+    ["elisp.bzl"],
+    visibility = ["//docs:__pkg__"],
+)

--- a/elisp/extensions/elisp.bzl
+++ b/elisp/extensions/elisp.bzl
@@ -1,0 +1,116 @@
+# Copyright 2023, 2024, 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines the `elisp` module extension."""
+
+load("@bazel_skylib//lib:modules.bzl", "modules")
+
+visibility("public")
+
+_http_archive = tag_class(
+    doc = """Downloads an archive file over HTTP and makes its contents
+available as an `elisp_library`.  This tag class is very similar to
+[`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive),
+except that it always generates a BUILD file containing a single `elisp_library`
+rule in the root package for all Emacs Lisp files in the archive.
+Test files (`…-test.el`, `…-tests.el`) and package metadata files (`…-pkg.el`)
+are excluded.
+The `elisp_library` rule is named `library` by default, unless overridden
+by the `target_name` attribute.""",
+    attrs = {
+        "name": attr.string(
+            doc = """Name of the repository to generate.""",
+            mandatory = True,
+        ),
+        "urls": attr.string_list(
+            doc = """List of archive URLs to try.
+See the [corresponding attribute for
+`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive-urls).""",
+            mandatory = True,
+            allow_empty = False,
+        ),
+        "integrity": attr.string(
+            doc = """Expected checksum of the archive file in [Subresource
+Integrity](https://www.w3.org/TR/SRI/) format.
+See the [corresponding attribute for
+`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive-integrity).""",
+            mandatory = True,
+        ),
+        "strip_prefix": attr.string(
+            doc = """Directory prefix to strip from the archive contents.
+See the [corresponding attribute for
+`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive-strip_prefix).""",
+        ),
+        "target_name": attr.string(
+            doc = """Name of the `elisp_library` target to generate.""",
+            default = "library",
+        ),
+        "exclude": attr.string_list(
+            doc = """Glob patterns of additional files to exclude from
+the library.""",
+        ),
+    },
+)
+
+def _elisp_http_archive_impl(ctx):
+    """Implementation of the `_elisp_http_archive` repository rule."""
+    ctx.download_and_extract(
+        url = ctx.attr.urls,
+        integrity = ctx.attr.integrity or fail("missing archive checksum"),
+        stripPrefix = ctx.attr.strip_prefix,
+    )
+    ctx.template(
+        "BUILD.bazel",
+        Label("//elisp:BUILD.template"),
+        {
+            '"[defs_bzl]"': repr(str(ctx.attr._defs_bzl)),
+            '"[target_name]"': repr(ctx.attr.target_name),
+            "[[exclude]]": repr(ctx.attr.exclude),
+        },
+        executable = False,
+    )
+
+_elisp_http_archive = repository_rule(
+    attrs = {
+        "urls": attr.string_list(mandatory = True, allow_empty = False),
+        "integrity": attr.string(mandatory = True),
+        "strip_prefix": attr.string(mandatory = True),
+        "target_name": attr.string(mandatory = True),
+        "exclude": attr.string_list(mandatory = True),
+        "_defs_bzl": attr.label(default = Label("//elisp:defs.bzl")),
+    },
+    implementation = _elisp_http_archive_impl,
+)
+
+def _elisp_impl(ctx):
+    """Implementation of the `elisp` module extension."""
+    for module in ctx.modules:
+        for arch in module.tags.http_archive:
+            _elisp_http_archive(
+                name = arch.name,
+                urls = arch.urls,
+                integrity = arch.integrity,
+                strip_prefix = arch.strip_prefix,
+                target_name = arch.target_name,
+                exclude = arch.exclude,
+            )
+    return modules.use_all_repos(ctx)
+
+elisp = module_extension(
+    doc = """Module extension for Emacs Lisp.""",
+    tag_classes = {
+        "http_archive": _http_archive,
+    },
+    implementation = _elisp_impl,
+)

--- a/examples/ext/MODULE.bazel
+++ b/examples/ext/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023, 2024 Google LLC
+# Copyright 2023, 2024, 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ local_path_override(
     path = "../..",
 )
 
-elisp = use_extension("@phst_rules_elisp//elisp:extensions.bzl", "elisp")
+elisp = use_extension("@phst_rules_elisp//elisp/extensions:elisp.bzl", "elisp")
 elisp.http_archive(
     name = "dash",
     exclude = ["dash-functional.el"],

--- a/examples/ext/MODULE.bazel.lock
+++ b/examples/ext/MODULE.bazel.lock
@@ -185,16 +185,16 @@
         ]
       }
     },
-    "@@phst_rules_elisp+//elisp:extensions.bzl%elisp": {
+    "@@phst_rules_elisp+//elisp/extensions:elisp.bzl%elisp": {
       "general": {
-        "bzlTransitiveDigest": "cBvDLFFnQbEadDiZxWUPlOP/eB4j9ZbjwKKG4v31EV8=",
-        "usagesDigest": "6mFjFWWQGjuMfZ4GX13pmOeiqlTo8nyRVAXYA9HOCGI=",
+        "bzlTransitiveDigest": "keXnJq03rxZE+i99Dizlz6cTSsttnIgR3nNdSSwFrZg=",
+        "usagesDigest": "VKYj6lzvfUzIuICEHfBh+99ZoqFiEr9KR+03L+rSdH8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "dash": {
-            "repoRuleId": "@@phst_rules_elisp+//elisp:extensions.bzl%_elisp_http_archive",
+            "repoRuleId": "@@phst_rules_elisp+//elisp/extensions:elisp.bzl%_elisp_http_archive",
             "attributes": {
               "urls": [
                 "https://github.com/magnars/dash.el/archive/refs/tags/2.19.1.zip"


### PR DESCRIPTION
See
https://docs.google.com/document/d/1L1JFgjpZ7SrBinb24DC_5nTIELeYDacikcme-YcA7xs/view?tab=t.0#heading=h.cy0m49ne5key for the structure that’s nowadays recommended.