### PR TITLE
Run Makeinfo through Perl.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -224,7 +224,7 @@
     },
     "//private:extensions.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "46Zc9yYJTPme4Mn3PLFEXOvc0P2d8YAW5uNdtdRDRi4=",
+        "bzlTransitiveDigest": "hZM7M+c4j6RYRX3WqrFkHQaXnuSuHT0R6pKchMo6g44=",
         "usagesDigest": "8Xi2p2FiSBOktLQxSGs2qDuwuwNYOAjVjClaeFzhjs4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -303,7 +303,7 @@
     },
     "//private:extensions.bzl%dev_deps": {
       "general": {
-        "bzlTransitiveDigest": "46Zc9yYJTPme4Mn3PLFEXOvc0P2d8YAW5uNdtdRDRi4=",
+        "bzlTransitiveDigest": "hZM7M+c4j6RYRX3WqrFkHQaXnuSuHT0R6pKchMo6g44=",
         "usagesDigest": "I7uLfCIDw4EhUdOX1jGaNva/lcz1d50YMTTpU5XdnJY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -32,13 +32,16 @@ elisp_manual(
     out = "manual.texi",
 )
 
-# This rule assumes that Texinfo is installed locally.
+# This rule assumes that Perl and Texinfo are installed locally.
 genrule(
     name = "info",
     srcs = ["manual.texi"],
     outs = ["rules_elisp.info"],
-    cmd = "$(execpath @local_texinfo//:makeinfo) --no-split --output=$@ -- $<",
-    tools = ["@local_texinfo//:makeinfo"],
+    cmd = "$(execpath @local_texinfo//:perl) -w $(execpath @local_texinfo//:makeinfo) --no-split --output=$@ -- $<",
+    tools = [
+        "@local_texinfo//:makeinfo",
+        "@local_texinfo//:perl",
+    ],
 )
 
 DOCS = [

--- a/examples/ext/MODULE.bazel.lock
+++ b/examples/ext/MODULE.bazel.lock
@@ -223,7 +223,7 @@
     },
     "@@phst_rules_elisp+//private:extensions.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "46Zc9yYJTPme4Mn3PLFEXOvc0P2d8YAW5uNdtdRDRi4=",
+        "bzlTransitiveDigest": "hZM7M+c4j6RYRX3WqrFkHQaXnuSuHT0R6pKchMo6g44=",
         "usagesDigest": "cDR0RtqIctLo0K/hZsKwxjvAMTgse8kkZKVh3uQiwEk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/private/extensions.bzl
+++ b/private/extensions.bzl
@@ -87,7 +87,11 @@ def _local_texinfo_repository_impl(ctx):
     makeinfo = ctx.getenv("MAKEINFO", "makeinfo") or fail("MAKEINFO is empty")
     if "/" not in makeinfo and "\\" not in makeinfo:
         makeinfo = ctx.which(makeinfo) or fail("Texinfo not installed")
-    ctx.symlink(makeinfo, "makeinfo.exe")
+    ctx.symlink(makeinfo, "makeinfo.pl")
+
+    perl = ctx.which("perl") or fail("Perl not installed")
+    ctx.symlink(perl, "perl.exe")
+
     ctx.template(
         "BUILD.bazel",
         Label("//private:texinfo.BUILD.template"),

--- a/private/texinfo.BUILD.template
+++ b/private/texinfo.BUILD.template
@@ -17,8 +17,13 @@ load("[native_binary.bzl]", "native_binary")
 package(default_visibility = ["[docs:__pkg__]"])
 
 native_binary(
+    name = "perl",
+    src = "perl.exe",
+)
+
+filegroup(
     name = "makeinfo",
-    src = "makeinfo.exe",
+    srcs = ["makeinfo.pl"],
 )
 
 # Local Variables:


### PR DESCRIPTION
Makeinfo is a Perl script, which isn’t directly executable on Windows.