### PR TITLE
Don’t emit load statements for module extensions.

### DIFF
--- a/docs/generate.py
+++ b/docs/generate.py
@@ -171,7 +171,10 @@ class _Generator:
         self._write(
             f'#+ATTR_TEXINFO: :options {{Module extension}} {name} {tags}\n')
         self._write('#+BEGIN_deftp\n')
-        self._load(ext.origin_key)
+        self._write('#+BEGIN_SRC bazel-module\n')
+        self._write(
+            f'{name} = use_extension("{ext.origin_key.file}", "{name}")\n')
+        self._write('#+END_SRC\n')
         self._write(_markdown(ext.doc_string).lstrip())
         self._write(f'The ~{name}~ module extension '
                     f'provides the following tag classes:\n\n')

--- a/index.html
+++ b/index.html
@@ -1336,7 +1336,7 @@ Next: <a href="#Emacs-Starlark-symbols" accesskey="n" rel="next">Symbols defined
 <dl class="first-deftp def-block">
 <dt class="deftp def-line" id="index-elisp"><span class="category-def">Module extension: </span><span><strong class="def-name">elisp</strong> <var class="def-var-arguments">http_archive</var><a class="copiable-link" href="#index-elisp"> &para;</a></span></dt>
 <dd><div class="example">
-<pre class="example-preformatted">load(&quot;@phst_rules_elisp//elisp/extensions:elisp.bzl&quot;, &quot;&quot;)
+<pre class="example-preformatted">elisp = use_extension(&quot;@phst_rules_elisp//elisp/extensions:elisp.bzl&quot;, &quot;elisp&quot;)
 </pre></div>
 <p>Module extension for Emacs Lisp.
 </p>


### PR DESCRIPTION
These are loaded with use_extension instead of load.