### PR TITLE
Revert "Add a Gazelle directive for a manual import."

### DIFF
--- a/gazelle/extension.go
+++ b/gazelle/extension.go
@@ -16,15 +16,11 @@ package gazelle
 
 import (
 	"log"
-	"maps"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/label"
 )
 
-type extension struct {
-	providers map[Feature]label.Label
-}
+type extension struct{}
 
 func initExtension(c *config.Config) *extension {
 	ext := getExtension(c)
@@ -49,22 +45,5 @@ func getExtension(c *config.Config) *extension {
 }
 
 func (e *extension) clone() *extension {
-	return &extension{maps.Clone(e.providers)}
-}
-
-func (e *extension) addProvider(lbl label.Label, feat Feature) {
-	if e.providers == nil {
-		e.providers = make(map[Feature]label.Label)
-	}
-	if prev, ok := e.providers[feat]; ok {
-		log.Printf("feature %s provided by both %s and %s", feat, prev, lbl)
-	}
-	e.providers[feat] = lbl
-}
-
-func (e *extension) provider(feat Feature) label.Label {
-	if e == nil {
-		return label.NoLabel
-	}
-	return e.providers[feat]
+	return &extension{}
 }

--- a/gazelle/language.go
+++ b/gazelle/language.go
@@ -20,8 +20,6 @@ package gazelle
 
 import (
 	"flag"
-	"log"
-	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
@@ -42,29 +40,13 @@ func (elisp) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
 
 func (elisp) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
 
-func (elisp) KnownDirectives() []string {
-	var r []string
-	for k := range directives {
-		r = append(r, k)
-	}
-	return r
-}
+func (elisp) KnownDirectives() []string { return nil }
 
 func (elisp) Configure(c *config.Config, rel string, f *rule.File) {
 	// We always rely on the imports index to write deps attributes.
 	c.IndexLibraries = true
 
-	ext := initExtension(c)
-
-	if f != nil {
-		for _, dir := range f.Directives {
-			fun, ok := directives[dir.Key]
-			if !ok {
-				continue
-			}
-			fun(f, dir, ext)
-		}
-	}
+	initExtension(c)
 }
 
 func (elisp) Name() string { return languageName }
@@ -108,24 +90,6 @@ func (elisp) Loads() []rule.LoadInfo {
 }
 
 func (elisp) Fix(c *config.Config, f *rule.File) {}
-
-var directives = map[string]func(*rule.File, rule.Directive, *extension){
-	"elisp_provide": processProvide,
-}
-
-func processProvide(f *rule.File, dir rule.Directive, ext *extension) {
-	before, after, ok := strings.Cut(dir.Value, "=")
-	if !ok || before == "" || after == "" {
-		log.Printf("%s: invalid directive %s %s", f.Path, dir.Key, dir.Value)
-		return
-	}
-	lbl, err := label.Parse(before)
-	if err != nil {
-		log.Printf("%s: invalid label %q in directive: %s", f.Path, before, err)
-		return
-	}
-	ext.addProvider(lbl.Abs("", f.Pkg), Feature(after))
-}
 
 const (
 	libraryKind = "elisp_library"

--- a/gazelle/resolve.go
+++ b/gazelle/resolve.go
@@ -58,10 +58,6 @@ func (elisp) Resolve(
 }
 
 func resolveFeature(c *config.Config, ix *resolve.RuleIndex, from label.Label, feat Feature) label.Label {
-	if lbl := getExtension(c).provider(feat); lbl != label.NoLabel {
-		return lbl
-	}
-
 	spec := feat.importSpec()
 	if lbl, ok := resolve.FindRuleWithOverride(c, spec, languageName); ok && lbl != label.NoLabel {
 		return lbl


### PR DESCRIPTION
This reverts commit e8ff6afe0354fb96f5f696e32e2b7742c3047df3.

The gazelle:resolve directive already provides the same functionality.