### PR TITLE
Revert "Run Go test in the expected directory."

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -64,7 +64,6 @@ go_test(
         "JUnit.xsd",
         "coverage.dat",
     ],
-    rundir = ".",
     deps = [
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",


### PR DESCRIPTION
This reverts commit de8baae35e6365e0073e4cc15f34408022ea4aab.

This doesn't appear to be necessary any more.