### PR TITLE
Run tests under newly-released Bazel 7.5.0.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        bazel: [7.2.1, 7.4.1, 8.0.1, latest]
+        bazel: [7.2.1, 7.5.0, 8.0.1, latest]
         os: [ubuntu-latest, macos-latest, windows-latest]
         cc: [gcc, clang, msvc]
         exclude:


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/releases/tag/7.5.0.