### PR TITLE
Fix incorrect code.

### DIFF
--- a/elisp/private/tools/ert-runner.el
+++ b/elisp/private/tools/ert-runner.el
@@ -834,9 +834,10 @@ TABLE."
     (declare (indent 2) (debug t))
     (macroexp-let2* nil ((key key) (table table))
       (let ((value (make-symbol "value"))
-            (default (cons nil nil)))  ; unique object
-        `(let ((,value (gethash ,key ,table ',default)))
-           (if (eq ,value ',default)
+            (default (make-symbol "default")))
+        `(let* ((,default (cons nil nil))  ; unique object
+                (,value (gethash ,key ,table ,default)))
+           (if (eq ,value ,default)
                (puthash ,key ,(macroexp-progn body) ,table)
              ,value))))))
 


### PR DESCRIPTION
We need to create the default object at execution time instead of macro expansion time to ensure that it’s the same object throughout the expansion.