### PR TITLE
Skip a test that doesn’t work in Emacs 30.1.

### DIFF
--- a/tests/ert_test.go
+++ b/tests/ert_test.go
@@ -280,6 +280,17 @@ func Test(t *testing.T) {
 			},
 		},
 	}
+	if emacsVersion == "30.1" {
+		// https://bugs.gnu.org/76447
+		abort := &wantReport.TestCases[0]
+		abort.Failure = message{}
+		abort.Skipped = message{
+			Message:     `Test skipped: ((skip-unless (not (string-equal emacs-version "30.1"))) :form (not t) :value nil)`,
+			Description: "something",
+		}
+		wantReport.Failures--
+		wantReport.Skipped++
+	}
 	if diff := cmp.Diff(
 		gotReport, wantReport,
 		cmp.Transformer("time.Time", toTime),

--- a/tests/test.el
+++ b/tests/test.el
@@ -60,6 +60,8 @@
   (error "Boo"))
 
 (ert-deftest abort ()
+  ;; https://bugs.gnu.org/76447
+  (skip-unless (not (string-equal emacs-version "30.1")))
   (signal 'undefined-error-symbol '("Boo")))
 
 (ert-deftest throw ()


### PR DESCRIPTION
See https://bugs.gnu.org/76447.