### PR TITLE
Revert "Save JSON profile files from CI"

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -64,11 +64,3 @@ jobs:
         shell: bash
         run: |
           make check-extra
-      - name: Upload profiles
-        uses: actions/upload-artifact@v4
-        with:
-          name: >-
-            profiles for Bazel version ${{matrix.bazel}} on ${{runner.os}}
-            compiled with ${{matrix.cc}}
-          path: ${{runner.temp}}/profiles/*.json.gz
-          if-no-files-found: ignore


### PR DESCRIPTION
This reverts commit 78c6626eb33a25e25a35337d2a6f3aad9913eb6d.

The profiles are no longer generated (commit d9b397678c2dabc524c0af34073b017de821824c), so the upload will never work.