### PR TITLE
Don’t install Python as part of the setup action.

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -31,10 +31,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
     - name: Install APT packages
       shell: bash
       run: sudo apt-get update && sudo apt-get install libxml2-utils


### PR DESCRIPTION
Python shouldn’t be needed any more after
commit d8e6622566ab76c4d7c20af67e31fa0ad38375a5,
and the Bazel toolchain downloads the correct interpreter automatically.