### PR TITLE
Use decomposed characters in filenames.

### DIFF
--- a/elisp/private/tools/binary_test.py
+++ b/elisp/private/tools/binary_test.py
@@ -45,7 +45,7 @@ class BinaryTest(absltest.TestCase):
             run_files.resolve(pathlib.PurePosixPath(FLAGS.launcher)),
             '--option',
             input_file,
-            ''' \t\n\r\f äα𝐴🐈'\\\"''',
+            ''' \t\n\r\f äα𝐴🐈'\\\"''',
             r'/:C:\Temp\output.dat' if windows else '/:/tmp/output.dat',
         ]
         subprocess.run(args, check=True)

--- a/elisp/private/tools/load_test.py
+++ b/elisp/private/tools/load_test.py
@@ -33,14 +33,14 @@ class AddPathTest(absltest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             load.add_path(runfiles.Runfiles({'RUNFILES_DIR': directory}), args,
                           [pathlib.PurePosixPath('foo'),
-                           pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')],
+                           pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')],
                           pathlib.PurePosixPath('unused/runfiles.elc'))
         base = pathlib.Path(directory)
         self.assertListEqual(
             args,
             ['--foo',
              '--directory=' + str(base / 'foo'),
-             '--directory=' + str(base / 'bar \t\n\r\f äα𝐴🐈\'\0\\"')])
+             '--directory=' + str(base / 'bar \t\n\r\f äα𝐴🐈\'\0\\"')])
 
     def test_manifest(self) -> None:
         """Unit test for manifest-based runfiles."""
@@ -58,7 +58,7 @@ class AddPathTest(absltest.TestCase):
                 runfiles.Runfiles({'RUNFILES_MANIFEST_FILE': str(manifest)}),
                 args,
                 [pathlib.PurePosixPath('foo'),
-                 pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')],
+                 pathlib.PurePosixPath('bar \t\n\r\f äα𝐴🐈\'\0\\"')],
                 pathlib.PurePosixPath('repository/runfiles.elc'))
         self.assertListEqual(
             args,
@@ -66,7 +66,7 @@ class AddPathTest(absltest.TestCase):
              '--load=' + str(runfiles_elc),
              '--funcall=elisp/runfiles/install-handler',
              '--directory=/bazel-runfile:foo',
-             '--directory=/bazel-runfile:bar \t\n\r\f äα𝐴🐈\'\0\\"'])
+             '--directory=/bazel-runfile:bar \t\n\r\f äα𝐴🐈\'\0\\"'])
 
 
 if __name__ == '__main__':

--- a/elisp/private/tools/manifest_test.py
+++ b/elisp/private/tools/manifest_test.py
@@ -47,7 +47,7 @@ class ManifestTest(absltest.TestCase):
         with io.StringIO() as file:
             manifest.write(opts,
                            [pathlib.PurePath('in-1'), pathlib.PurePath('in-2')],
-                           [pathlib.PurePath('out \t\n\r\f äα𝐴🐈\'\0\\"')],
+                           [pathlib.PurePath('out \t\n\r\f äα𝐴🐈\'\0\\"')],
                            file)
             self.assertDictEqual(
                 json.loads(file.getvalue()),
@@ -55,8 +55,8 @@ class ManifestTest(absltest.TestCase):
                     'root': 'RUNFILES_ROOT',
                     'loadPath': ['load-dir'],
                     'inputFiles': ['in-1', 'in-2', 'load-file', 'data-file'],
-                    'outputFiles': ['out \t\n\r\f äα𝐴🐈\'\0\\"'],
-                    'tags': ['tag-1', 'tag-2 \t\n\r\f äα𝐴🐈\'\0\\"'],
+                    'outputFiles': ['out \t\n\r\f äα𝐴🐈\'\0\\"'],
+                    'tags': ['tag-1', 'tag-2 \t\n\r\f äα𝐴🐈\'\0\\"'],
                 })
 
 

--- a/elisp/private/tools/wrap.py
+++ b/elisp/private/tools/wrap.py
@@ -71,7 +71,7 @@ def main() -> None:
                 '--option',
                 str(run_files.resolve(pathlib.PurePosixPath(
                     'phst_rules_elisp/elisp/private/tools/binary.cc'))),
-                ' \t\n\r\f äα𝐴🐈\'\\"',
+                ' \t\n\r\f äα𝐴🐈\'\\"',
                 '/:' + str(output_file),
             ]
             self.assertListEqual(got, want)

--- a/tests/runfiles/runfiles-test.el
+++ b/tests/runfiles/runfiles-test.el
@@ -49,7 +49,7 @@
 (ert-deftest elisp/runfiles/special-chars/directory ()
   (let* ((windows (memq system-type '(ms-dos windows-nt)))
          (directory (make-temp-file "runfiles-test-" :directory))
-         (filename (concat "testäα𝐴🐈' " (unless windows "\t\n\\") ".txt"))
+         (filename (concat "testäα𝐴🐈' " (unless windows "\t\n\\") ".txt"))
          (target (expand-file-name filename directory))
          (runfiles (elisp/runfiles/make :manifest "/invalid.manifest"
                                         :directory directory))
@@ -67,8 +67,8 @@
          (runfiles (elisp/runfiles/make :manifest manifest
                                         :directory "/invalid/")))
     (pcase-dolist (`(,source ,target)
-                   '(("testäα𝐴🐈'.txt"
-                      "/:/runfiles/testäα𝐴🐈'.txt")
+                   '(("testäα𝐴🐈'.txt"
+                      "/:/runfiles/testäα𝐴🐈'.txt")
                      ("target-with-space"
                       "/:/runfiles/with space\\and backslash")
                      ("target-with-newline"

--- a/tests/runfiles/test-manifest
+++ b/tests/runfiles/test-manifest
@@ -1,6 +1,6 @@
 __init__.py 
 foo/bar runfiles/foo/bar
-testäα𝐴🐈'.txt /runfiles/testäα𝐴🐈'.txt
+testäα𝐴🐈'.txt /runfiles/testäα𝐴🐈'.txt
 target-with-space /runfiles/with space\and backslash
  target-with-newline /runfiles/with\nnewline\band backslash
  source\swith\sspace,\nnewline,\band\sbackslash /runfiles/with space,\nnewline,\band backslash


### PR DESCRIPTION
This is for compatibility with macOS, which always stores filenames in NFD form.