### PR TITLE
Hard-code Emacs release archive URLs in MODULE.bazel.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,8 +55,11 @@ emacs_repository(
     integrity = "sha384-1LIwxBtAr9RzK3VJ359OfOh/PN83fyfl7uckmMw+Z0mKabbOOsvy00PhXvm5wJtf",
     mode = "source",
     output = "emacs.tar.xz",
-    path = "/emacs/emacs-29.4.tar.xz",
     strip_prefix = "emacs-29.4",
+    urls = [
+        "https://ftpmirror.gnu.org/emacs/emacs-29.4.tar.xz",
+        "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz",
+    ],
 )
 
 emacs_repository(
@@ -64,11 +67,14 @@ emacs_repository(
     integrity = "sha384-wu5kKCCMX6BLgSoUfMEUf1gLk4Ua+rWa8mldAeW+Y6q+RXyCmdPZP/XuJPO9uWrt",
     mode = "release",
     output = "emacs.zip",
-    path = "/emacs/windows/emacs-29/emacs-29.4.zip",
     strip_prefix = "",
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
+    ],
+    urls = [
+        "https://ftpmirror.gnu.org/emacs/windows/emacs-29/emacs-29.4.zip",
+        "https://ftp.gnu.org/gnu/emacs/windows/emacs-29/emacs-29.4.zip",
     ],
 )
 
@@ -77,8 +83,11 @@ emacs_repository(
     integrity = "sha384-2K37C4VadoRIlCTmMWJA75AtWC05CrVQ4D80EpbAu1Fyk9MXLgbIbxf0CFjcZ0jC",
     mode = "source",
     output = "emacs.tar.xz",
-    path = "/emacs/emacs-30.1.tar.xz",
     strip_prefix = "emacs-30.1",
+    urls = [
+        "https://ftpmirror.gnu.org/emacs/emacs-30.1.tar.xz",
+        "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz",
+    ],
 )
 
 emacs_repository(
@@ -86,11 +95,14 @@ emacs_repository(
     integrity = "sha384-eRRAnADE9t62y4bk8HyAi4SM1WoygTtysP+PjN8bp18LsB9ZBIsQe16w5+8XTkpc",
     mode = "release",
     output = "emacs.zip",
-    path = "/emacs/windows/emacs-30/emacs-30.1.zip",
     strip_prefix = "",
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
+    ],
+    urls = [
+        "https://ftpmirror.gnu.org/emacs/windows/emacs-30/emacs-30.1.zip",
+        "https://ftp.gnu.org/gnu/emacs/windows/emacs-30/emacs-30.1.zip",
     ],
 )
 

--- a/elisp/private/emacs_repository.bzl
+++ b/elisp/private/emacs_repository.bzl
@@ -17,14 +17,10 @@
 visibility("private")
 
 def _emacs_repository_impl(ctx):
-    path = ctx.attr.path
     output = ctx.attr.output
     ctx.download(
         integrity = ctx.attr.integrity or fail("archive integrity missing"),
-        url = [
-            "https://ftpmirror.gnu.org" + path,
-            "https://ftp.gnu.org/gnu" + path,
-        ],
+        url = ctx.attr.urls or fail("archive URLs missing"),
         output = output,
     )
     ctx.template(
@@ -45,7 +41,7 @@ def _emacs_repository_impl(ctx):
 
 emacs_repository = repository_rule(
     attrs = {
-        "path": attr.string(mandatory = True),
+        "urls": attr.string_list(mandatory = True, allow_empty = False),
         "integrity": attr.string(mandatory = True),
         "output": attr.string(mandatory = True),
         "strip_prefix": attr.string(),


### PR DESCRIPTION
Emacs releases are rare enough to warrant the duplication.