### PR TITLE
Don’t add byte-order mark to module definition files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,6 @@ repos:
   - id: double-quote-string-fixer
   - id: end-of-file-fixer
   - id: fix-byte-order-marker
-    exclude: '\.def$'
   - id: fix-encoding-pragma
     args: [--remove]
   - id: forbid-submodules

--- a/elisp/private/tools/module.def
+++ b/elisp/private/tools/module.def
@@ -1,4 +1,4 @@
-﻿; Copyright 2022 Google LLC
+; Copyright 2022, 2025 Google LLC
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ EXPORTS
 
 ; Local Variables:
 ; mode: conf-windows
-; coding: utf-8-with-signature-dos
+; coding: ascii-dos
 ; End:


### PR DESCRIPTION
lld-link doesn’t support them and emits an error

    lld-link: error: unknown directive: ﻿

where the “unknown directive” is the byte-order mark.

Without byte-order mark, the Visual C++ linker will interpret the module definition file in the legacy “ANSI” codepage.  Force the file to ASCII-only to ensure this doesn’t cause any trouble.