### PR TITLE
Prevent warning when compiling with Clang-CL.

### DIFF
--- a/elisp/private/cc_config.bzl
+++ b/elisp/private/cc_config.bzl
@@ -78,6 +78,7 @@ DEFINES = [
         "STRICT",
         "NOMINMAX",
         "WIN32_LEAN_AND_MEAN",
+        "NONAMELESSUNION",
     ],
 })
 


### PR DESCRIPTION
See https://devblogs.microsoft.com/oldnewthing/20170907-00/?p=96956.