### PR TITLE
Enable GNU extensions when building Emacs with GCC.

### DIFF
--- a/elisp/private/BUILD
+++ b/elisp/private/BUILD
@@ -162,6 +162,9 @@ cc_defaults(
             "-fno-diagnostics-color",
         ],
         "//conditions:default": [],
+    }) + select({
+        "@rules_cc//cc/compiler:gcc": ["-std=gnu11"],
+        "//conditions:default": [],
     }),
     defines = [],
     features = [


### PR DESCRIPTION
At least for Emacs 30.1, building Emacs with GCC requires the GNU extensions due to its use of the “asm” keyword in src/lisp.h; see https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html and https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html.