### PR TITLE
Also run bazel mod graph.

### DIFF
--- a/check.ps1
+++ b/check.ps1
@@ -36,6 +36,7 @@ function Run-Bazel {
 
 function Run-Tests {
     Run-Bazel 'test' @args '--' '//...'
+    Run-Bazel 'mod' 'graph' > $null
 }
 
 # All potentially supported Emacs versions.


### PR DESCRIPTION
This finds some errors in the module graph that bazel build doesn’t find.