### PR TITLE
Revert "Add a test that we don’t accidentally try to override production dependencies"

### DIFF
--- a/dev/BUILD
+++ b/dev/BUILD
@@ -94,7 +94,6 @@ go_test(
     size = "small",
     srcs = ["version_test.go"],
     embedsrcs = ["MODULE.bazel"],
-    deps = ["@com_github_bazelbuild_buildtools//build"],
 )
 
 copy_file(

--- a/dev/version_test.go
+++ b/dev/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023, 2024 Google LLC
+// Copyright 2023, 2024, 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,45 +15,8 @@
 package version_test
 
 import (
-	"strings"
-	"testing"
-
 	_ "embed"
-
-	"github.com/bazelbuild/buildtools/build"
 )
-
-func TestOverrides(t *testing.T) {
-	file, err := build.ParseModule("MODULE.bazel", moduleContent)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	deps := make(map[string]bool)
-	for _, rule := range file.Rules("bazel_dep") {
-		deps[rule.Name()] = rule.AttrLiteral("dev_dependency") == "True"
-	}
-	if len(deps) == 0 {
-		t.Error("no dependencies found")
-	}
-
-	for _, rule := range file.Rules("") {
-		kind := rule.Kind()
-		if !strings.HasSuffix(kind, "_override") {
-			continue
-		}
-		name := rule.AttrString("module_name")
-		dev, ok := deps[name]
-		if !ok {
-			t.Errorf("unknown dependency %s overridden by %s", name, kind)
-		}
-		// Overrides only work in root modules, so this dependency
-		// wouldn’t work outside of our own workspace.
-		if !dev {
-			t.Errorf("production dependency %s is overridden using %s", name, kind)
-		}
-	}
-}
 
 //go:embed MODULE.bazel
 var moduleContent []byte


### PR DESCRIPTION
This reverts commit 726890338669f8193eab7fae314af5dc75002d39.

The test doesn't pull its weight.