### PR TITLE
Expand default directory before quoting it.

### DIFF
--- a/elisp/private/tools/compile.el
+++ b/elisp/private/tools/compile.el
@@ -39,7 +39,8 @@
       attempt-orderly-shutdown-on-fatal-signal nil)
 
 ;; Ensure filenames in the output are relative to the current directory.
-(setq byte-compile-root-dir (file-name-quote default-directory))
+(setq byte-compile-root-dir
+      (file-name-quote (expand-file-name default-directory)))
 
 ;; Emacs 29 doesn’t yet support the ‘ftype’ declaration.  Ensure that
 ;; compilation works without warnings.


### PR DESCRIPTION
Otherwise it might start with ~, causing filename relativization to fail.