### PR TITLE
Revert "Synchronize Go version with version specified in go.mod"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -163,10 +163,6 @@ single_version_override(
 
 # Go-specific dependencies
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
-
-# FIXME: Use go_sdk.from_file once
-# https://github.com/bazel-contrib/rules_go/issues/4307 is fixed.
-go_sdk.download(version = "1.23.6")
 go_sdk.nogo(nogo = "//dev:nogo")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)


### PR DESCRIPTION
This reverts commit 9d5621e0a44b2dd6f9a1fbc4524fbb8c18d66142.

New rules_go should have an up-to-date version of Go by default.