### PR TITLE
Revert "Attempt to work around nondeterminism on Windows."

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -124,10 +124,6 @@ register_toolchains("@local_config_cc_toolchains//:all")
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
 python.toolchain(
     configure_coverage_tool = True,
-    # Attempt to work around nondeterminism on Windows.  See
-    # https://github.com/bazelbuild/rules_python/pull/713 and
-    # https://github.com/bazelbuild/rules_python/pull/907.
-    ignore_root_user_error = True,
     python_version = "3.12",
 )
 


### PR DESCRIPTION
This reverts commit eb60756443d63ab190095a0384094943115daf52.

ignore_root_user_error is now true by default,
cf. https://github.com/bazel-contrib/rules_python/commit/c7aa9893c146e33a5e76dbbd83115e91a8836021.