### PR TITLE
Revert "Work around https://github.com/actions/runner-images/issues/12435"

### DIFF
--- a/c-std.bazelrc
+++ b/c-std.bazelrc
@@ -28,12 +28,6 @@ build:macos --conlyopt='-std=c11' --host_conlyopt='-std=c11'
 build:windows --cxxopt='/std:c++17' --host_cxxopt='/std:c++17'
 build:windows --conlyopt='/std:c11' --host_conlyopt='/std:c11'
 
-# Work around https://github.com/actions/runner-images/issues/12435.
-# TODO: Remove once https://github.com/actions/runner-images/issues/12435 is
-# fixed.
-build:windows --copt='/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH'
-build:windows --host_copt='/D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH'
-
 # Local Variables:
 # mode: bazelrc
 # End:


### PR DESCRIPTION
This reverts commit f436aa170238723ec68e6285ba1ebfa9a43da1e0.

Upstream issue should be fixed by now.