### PR TITLE
Initialize fake hit count for first line to function call count.

### DIFF
--- a/elisp/private/tools/run-test.el
+++ b/elisp/private/tools/run-test.el
@@ -728,7 +728,7 @@ Lisp source file that has been instrumented with Edebug using
        (unless (eq (marker-buffer begin) buffer)
          (error "Function %s got redefined in some other file" name))
        (cl-incf functions-hit (min calls 1))
-       (@hash-get-or-put begin-line lines 0)
+       (@hash-get-or-put begin-line lines calls)
        (cl-assert (eql (length coverage) (length offsets)) :show-args)
        (cl-loop
         for offset across offsets

--- a/tests/coverage.dat
+++ b/tests/coverage.dat
@@ -36,7 +36,7 @@ BRDA:57,0,0,3
 BRDA:57,0,1,0
 BRF:26
 BRH:10
-DA:29,0
+DA:29,1
 DA:32,1
 DA:33,1
 DA:34,0
@@ -64,6 +64,6 @@ DA:57,3
 DA:59,1
 DA:60,1
 DA:61,1
-LH:22
+LH:23
 LF:28
 end_of_record


### PR DESCRIPTION
Otherwise, the record contains bogus uncovered lines.