### PR TITLE
Assume that https://bugs.gnu.org/76447 won’t be fixed in Emacs 30.

### DIFF
--- a/tests/test.el
+++ b/tests/test.el
@@ -63,7 +63,7 @@
 
 (ert-deftest abort ()
   ;; https://bugs.gnu.org/76447
-  (skip-unless (not (string-equal emacs-version "30.1")))
+  (skip-unless (not (eql emacs-major-version 30)))
   (signal 'undefined-error-symbol '("Boo")))
 
 (ert-deftest throw ()


### PR DESCRIPTION
This simplifies the version checks.