### PR TITLE
Revert "Update Protocol Buffers to version 30."

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,9 +46,6 @@ build --//private:treat_warnings_as_errors
 
 build --compilation_mode=dbg --host_compilation_mode=dbg
 
-# https://github.com/protocolbuffers/protobuf/issues/20085
-build --define=protobuf_allow_msvc=true
-
 build:clang-cl --compiler=clang-cl --host_compiler=clang-cl
 build:clang-cl --extra_toolchains='@local_config_cc//:cc-toolchain-x64_windows-clang-cl'
 build:clang-cl --extra_execution_platforms='//elisp/private:windows_clang_cl'


### PR DESCRIPTION
This reverts commit 312bfa0a5a0212a55b0f07389c9f3d9b7c34e862.

Partial revert: only remove the Visual C++ workaround, which is no longer needed with Protocol Buffer 32, cf. https://protobuf.dev/news/2025-07-16/.