### PR TITLE
Remove -fno-exceptions

### DIFF
--- a/c-std.bazelrc
+++ b/c-std.bazelrc
@@ -19,10 +19,8 @@ common --enable_platform_specific_config
 # https://github.com/abseil/abseil-cpp/blob/master/FAQ.md#how-to-i-set-the-c-dialect-used-to-build-abseil.
 # On GNU/Linux, compiling the CGo parts of the Go standard library fails without
 # GNU extensions, so we use gnu11 instead of c11.
-build:linux --copt='-fno-exceptions' --host_copt='-fno-exceptions'
 build:linux --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
 build:linux --conlyopt='-std=gnu11' --host_conlyopt='-std=gnu11'
-build:macos --copt='-fno-exceptions' --host_copt='-fno-exceptions'
 build:macos --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
 build:macos --conlyopt='-std=c11' --host_conlyopt='-std=c11'
 build:windows --cxxopt='/std:c++17' --host_cxxopt='/std:c++17'


### PR DESCRIPTION
This effectively revers commit 18cd259c165aaad20692b0500a58481d64a8bebb. Not using exceptions is a style decision, no need to change the ABI for that.