### PR TITLE
Remove C++ standard selection

### DIFF
--- a/c-std.bazelrc
+++ b/c-std.bazelrc
@@ -17,9 +17,6 @@ common --enable_platform_specific_config
 # Specify options that might modify code generation here instead of BUILD or
 # Starlark files.  See
 # https://github.com/abseil/abseil-cpp/blob/master/FAQ.md#how-to-i-set-the-c-dialect-used-to-build-abseil.
-build:linux --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
-build:macos --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
-build:windows --cxxopt='/std:c++17' --host_cxxopt='/std:c++17'
 build:windows --conlyopt='/std:c11' --host_conlyopt='/std:c11'
 
 # Local Variables:


### PR DESCRIPTION
C++17 is now the default in rules_cc,
cf. https://github.com/bazelbuild/rules_cc/blob/0.2.2/cc/private/toolchain/unix_cc_configure.bzl#L472 and
https://github.com/bazelbuild/rules_cc/blob/0.2.2/cc/private/toolchain/windows_cc_toolchain_config.bzl#L739.