### PR TITLE
Remove explicit C standard selection

### DIFF
--- a/c-std.bazelrc
+++ b/c-std.bazelrc
@@ -17,12 +17,8 @@ common --enable_platform_specific_config
 # Specify options that might modify code generation here instead of BUILD or
 # Starlark files.  See
 # https://github.com/abseil/abseil-cpp/blob/master/FAQ.md#how-to-i-set-the-c-dialect-used-to-build-abseil.
-# On GNU/Linux, compiling the CGo parts of the Go standard library fails without
-# GNU extensions, so we use gnu11 instead of c11.
 build:linux --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
-build:linux --conlyopt='-std=gnu11' --host_conlyopt='-std=gnu11'
 build:macos --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
-build:macos --conlyopt='-std=c11' --host_conlyopt='-std=c11'
 build:windows --cxxopt='/std:c++17' --host_cxxopt='/std:c++17'
 build:windows --conlyopt='/std:c11' --host_conlyopt='/std:c11'
 


### PR DESCRIPTION
The default for both GCC and Clang should now be recent enough.