### PR TITLE
Revert "Enable GNU extensions when building Emacs with GCC."

### DIFF
--- a/elisp/private/BUILD
+++ b/elisp/private/BUILD
@@ -164,9 +164,6 @@ cc_defaults(
             "-fno-diagnostics-color",
         ],
         "//conditions:default": [],
-    }) + select({
-        "@rules_cc//cc/compiler:gcc": ["-std=gnu11"],
-        "//conditions:default": [],
     }),
     defines = [],
     features = [


### PR DESCRIPTION
This reverts commit e1c8489866eb8aa0404cbf2d2b6b72b1ef66be01.

GNU extensions should now be enabled by default,
so this should no longer be needed.