### PR TITLE
Deprecate outs attribute of elisp_library

### DIFF
--- a/elisp/elisp_library.bzl
+++ b/elisp/elisp_library.bzl
@@ -67,8 +67,9 @@ files ending in `.el`, or module objects ending in `.so`, `.dylib`, or
             flags = ["DIRECT_COMPILE_TIME_INPUT"],
         ),
         "outs": attr.output_list(
-            doc = """List of byte-compiled Emacs Lisp files to be made available
-as targets.""",
+            doc = """Deprecated; use
+e.g. [select_file](https://github.com/bazelbuild/bazel-skylib/blob/main/docs/select_file_doc.md)
+instead.""",
         ),
         "data": attr.label_list(
             doc = "List of files to be made available at runtime.",

--- a/elisp/private/tools/BUILD
+++ b/elisp/private/tools/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
@@ -214,8 +215,14 @@ elisp_library(
     name = "run_test_el",
     testonly = True,
     srcs = ["run-test.el"],
-    outs = ["run-test.elc"],
     visibility = ["//tests/tools:__pkg__"],
+)
+
+select_file(
+    name = "run-test.elc",
+    testonly = True,
+    srcs = ":run_test_el",
+    subpath = "/" + package_name() + "/run-test.elc",
 )
 
 py_library(

--- a/elisp/runfiles/BUILD
+++ b/elisp/runfiles/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("//elisp:elisp_library.bzl", "elisp_library")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
 
@@ -27,6 +28,12 @@ licenses(["notice"])
 elisp_library(
     name = "runfiles",
     srcs = ["runfiles.el"],
-    outs = ["runfiles.elc"],
     visibility = ["//visibility:public"],
+)
+
+select_file(
+    name = "runfiles.elc",
+    srcs = ":runfiles",
+    subpath = "/" + package_name() + "/runfiles.elc",
+    visibility = ["//elisp/private/tools:__pkg__"],
 )

--- a/index.html
+++ b/index.html
@@ -190,10 +190,6 @@ compile cleanly and that you don’t control.  Boolean; optional; default:
 in <code class="code">.el</code>, or module objects ending in <code class="code">.so</code>, <code class="code">.dylib</code>, or <code class="code">.dll</code>.  List of
 labels; mandatory.
 </p></dd>
-<dt><code class="code">outs</code></dt>
-<dd><p>List of byte-compiled Emacs Lisp files to be made available as
-targets.  List of output files; optional; default: <code class="code">[]</code>.
-</p></dd>
 <dt><code class="code">data</code></dt>
 <dd><p>List of files to be made available at runtime.  List of labels;
 optional; default: <code class="code">[]</code>.

--- a/tests/runfiles/BUILD
+++ b/tests/runfiles/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_features//:features.bzl", "bazel_features")
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("//elisp:elisp_library.bzl", "elisp_library")
 load("//elisp:elisp_test.bzl", "elisp_test")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
@@ -46,5 +47,10 @@ elisp_test(
 elisp_library(
     name = "test_lib",
     srcs = ["test-lib.el"],
-    outs = ["test-lib.elc"],
+)
+
+select_file(
+    name = "test-lib.elc",
+    srcs = ":test_lib",
+    subpath = "/" + package_name() + "/test-lib.elc",
 )


### PR DESCRIPTION
It has always been a wart, and we can use select_file from Skylib instead.