### PR TITLE
Fix incorrect PYTHONPATH setting

### DIFF
--- a/dev/run_pylint.py
+++ b/dev/run_pylint.py
@@ -40,7 +40,10 @@ def main() -> None:
         raise FileNotFoundError('no source files found')
     srcset = frozenset(srcs)
     repository_path = [str(d) for d in args.path]
-    pythonpath = os.pathsep.join(sys.path + repository_path)
+    pythonpath = os.pathsep.join(repository_path)
+    inherited_path = os.getenv('PYTHONPATH')
+    if inherited_path:
+        pythonpath = os.pathsep.join([inherited_path, pythonpath])
     env = dict(os.environ, PYTHONPATH=pythonpath)
     result = subprocess.run(
         [sys.executable, '-m', 'pylint',


### PR DESCRIPTION
PYTHONPATH and sys.path are not the same,
cf. https://docs.python.org/3/library/sys.html#sys.path and https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH, so it’s not correct to set PYTHONPATH to sys.path.  Rather, extend the existing PYTHONPATH environmental variable.