### PR TITLE
Revert "Validate PYTHONPATH entries"

### DIFF
--- a/dev/run_pylint.py
+++ b/dev/run_pylint.py
@@ -27,7 +27,7 @@ def main() -> None:
     parser.add_argument('--out', type=pathlib.Path, required=True)
     parser.add_argument('--src', type=pathlib.Path, action='append',
                         default=[], dest='sources')
-    parser.add_argument('--import', type=_path_dir, action='append',
+    parser.add_argument('--import', type=pathlib.Path, action='append',
                         default=[], dest='path')
     parser.add_argument('--pylintrc', type=pathlib.Path, required=True)
     args = parser.parse_args()
@@ -53,12 +53,6 @@ def main() -> None:
         print(result.stdout)
         sys.exit(result.returncode)
     args.out.touch()
-
-
-def _path_dir(arg: str) -> pathlib.Path:
-    if not arg or ':' in arg:
-        raise ValueError(f'invalid path directory {arg!r}')
-    return pathlib.Path(arg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts commit 429e68be59b31f30aba3db2d1f6cb2e8a57359e9.

This is no longer needed after commit bb657e89cfaf0398c7fe5c096b9aec9600644ee1.