### PR TITLE
Don’t capture standard output of Pylint

### DIFF
--- a/dev/run_pylint.py
+++ b/dev/run_pylint.py
@@ -28,11 +28,9 @@ def main() -> None:
     result = subprocess.run(
         args.args,
         check=False,
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         encoding='utf-8', errors='backslashreplace')
     if result.returncode:
         print('$', shlex.join(result.args))
-        print(result.stdout)
         sys.exit(result.returncode)
 
 


### PR DESCRIPTION
Pylint should now be silent in case of no errors, so we don’t need to suppress its output manually.