### PR TITLE
Remove rundir attribute

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -115,7 +115,6 @@ go_test(
         shell.quote("--bin=$(rlocationpath :bin)"),
     ],
     data = ["bin"],
-    rundir = ".",
     deps = ["@rules_go//go/runfiles"],
 )
 


### PR DESCRIPTION
Apparently it’s no longer needed.