### PR TITLE
Factor out per-OS constants into separate files

### DIFF
--- a/tests/emacs_test.go
+++ b/tests/emacs_test.go
@@ -85,12 +85,6 @@ func TestRun(t *testing.T) {
 
 // Test that running a binary with a wrapper works.
 func TestRunWrapped(t *testing.T) {
-	var outputFile string
-	if os.PathSeparator == '/' {
-		outputFile = "/tmp/output.dat"
-	} else {
-		outputFile = `C:\Temp\output.dat`
-	}
 	cmd := exec.Command(
 		*launcher,
 		"--option",

--- a/tests/unix_test.go
+++ b/tests/unix_test.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2023, 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package tests_test
+
+const outputFile = "/tmp/output.dat"

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -1,0 +1,19 @@
+// Copyright 2020-2023, 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package tests_test
+
+const outputFile = `C:\Temp\output.dat`


### PR DESCRIPTION
See https://pkg.go.dev/cmd/go#hdr-Build_constraints.