### PR TITLE
Use floating version identifier for Bazel versions

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        bazel: [7.2.1, 7.6.1, 8.4.2, latest]
+        bazel: [7.2.1, 7.x, 8.x, latest]
         os: [ubuntu-latest, macos-latest, windows-latest]
         cc: [gcc-14, clang, msvc]
         exclude:


### PR DESCRIPTION
See https://github.com/bazelbuild/bazelisk#how-does-bazelisk-know-which-bazel-version-to-run.