### PR TITLE
Drop minor version numbers from repository and target names

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")
 emacs_repository = use_repo_rule("//elisp/private:emacs_repository.bzl", "emacs_repository")
 
 emacs_repository(
-    name = "gnu_emacs_29.4",
+    name = "gnu_emacs_29",
     integrity = "sha384-1LIwxBtAr9RzK3VJ359OfOh/PN83fyfl7uckmMw+Z0mKabbOOsvy00PhXvm5wJtf",
     mode = "source",
     output = "emacs.tar.xz",
@@ -58,7 +58,7 @@ emacs_repository(
 )
 
 emacs_repository(
-    name = "gnu_emacs_windows_29.4",
+    name = "gnu_emacs_windows_29",
     integrity = "sha384-wu5kKCCMX6BLgSoUfMEUf1gLk4Ua+rWa8mldAeW+Y6q+RXyCmdPZP/XuJPO9uWrt",
     mode = "release",
     output = "emacs.zip",
@@ -74,7 +74,7 @@ emacs_repository(
 )
 
 emacs_repository(
-    name = "gnu_emacs_30.2",
+    name = "gnu_emacs_30",
     integrity = "sha384-2hDJF2LcSpB7ZTLRyCpYBkXpMs1QVlANlrSPNfU6sUrrs57Q+7QY3Ff7MIYRwNRt",
     mode = "source",
     output = "emacs.tar.xz",
@@ -86,7 +86,7 @@ emacs_repository(
 )
 
 emacs_repository(
-    name = "gnu_emacs_windows_30.2",
+    name = "gnu_emacs_windows_30",
     integrity = "sha384-MeW1g2s6e5UBWMBYEU+FCMeLnZMKaiBo6BWfc4Re/Dy//JBaN7RXRJtzXLq9QTSg",
     mode = "release",
     output = "emacs.zip",

--- a/check.ps1
+++ b/check.ps1
@@ -43,8 +43,8 @@ function Run-Tests {
     }
 }
 
-# All potentially supported Emacs versions.
-$versions = '29.4', '30.2'
+# All supported Emacs major versions.
+$versions = '29', '30'
 
 $VerbosePreference = 'Continue'
 

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -37,14 +37,14 @@ toolchain(
 )
 
 toolchain(
-    name = "emacs_29.4_toolchain",
-    toolchain = "emacs_29.4",
+    name = "emacs_29_toolchain",
+    toolchain = "emacs_29",
     toolchain_type = ":toolchain_type",
 )
 
 toolchain(
-    name = "emacs_30.2_toolchain",
-    toolchain = "emacs_30.2",
+    name = "emacs_30_toolchain",
+    toolchain = "emacs_30",
     toolchain_type = ":toolchain_type",
 )
 
@@ -66,13 +66,13 @@ elisp_toolchain(
 )
 
 elisp_toolchain(
-    name = "emacs_29.4",
-    emacs = "//emacs:emacs_29.4",
+    name = "emacs_29",
+    emacs = "//emacs:emacs_29",
 )
 
 elisp_toolchain(
-    name = "emacs_30.2",
-    emacs = "//emacs:emacs_30.2",
+    name = "emacs_30",
+    emacs = "//emacs:emacs_30",
 )
 
 bzl_library(

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -26,33 +26,33 @@ licenses(["notice"])
 # keep
 alias(
     name = "emacs",
-    actual = ":emacs_30.2",
+    actual = ":emacs_30",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "module_header",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_30.2//:module_header",
-        "//conditions:default": "@gnu_emacs_30.2//:module_header",
+        "@platforms//os:windows": "@gnu_emacs_windows_30//:module_header",
+        "//conditions:default": "@gnu_emacs_30//:module_header",
     }),
     visibility = ["//visibility:public"],
 )
 
 alias(
-    name = "emacs_29.4",
+    name = "emacs_29",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_29.4//:emacs",
-        "//conditions:default": "@gnu_emacs_29.4//:emacs",
+        "@platforms//os:windows": "@gnu_emacs_windows_29//:emacs",
+        "//conditions:default": "@gnu_emacs_29//:emacs",
     }),
     visibility = ["//visibility:public"],
 )
 
 alias(
-    name = "emacs_30.2",
+    name = "emacs_30",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_30.2//:emacs",
-        "//conditions:default": "@gnu_emacs_30.2//:emacs",
+        "@platforms//os:windows": "@gnu_emacs_windows_30//:emacs",
+        "//conditions:default": "@gnu_emacs_30//:emacs",
     }),
     visibility = ["//visibility:public"],
 )

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -104,7 +104,7 @@ copy_file(
 alias(
     name = "builtin_features",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_30.2//:builtin_features",
-        "//conditions:default": "@gnu_emacs_30.2//:builtin_features",
+        "@platforms//os:windows": "@gnu_emacs_windows_30//:builtin_features",
+        "//conditions:default": "@gnu_emacs_30//:builtin_features",
     }),
 )


### PR DESCRIPTION
Now that we only support the latest minor version for each major version, we don’t need to include the minor version in the names any longer.