### PR TITLE
Use consistent arguments for instrumented_files_info

### DIFF
--- a/elisp/elisp_cc_module.bzl
+++ b/elisp/elisp_cc_module.bzl
@@ -105,7 +105,7 @@ def _elisp_cc_module_impl(ctx):
         coverage_common.instrumented_files_info(
             ctx,
             source_attributes = ["srcs"],
-            dependency_attributes = ["deps"],
+            dependency_attributes = ["deps", "data"],
             metadata_files = metadata_files,
         ),
     ]

--- a/elisp/elisp_library.bzl
+++ b/elisp/elisp_library.bzl
@@ -38,7 +38,7 @@ def _elisp_library_impl(ctx):
         coverage_common.instrumented_files_info(
             ctx,
             source_attributes = ["srcs"],
-            dependency_attributes = ["deps", "srcs"],
+            dependency_attributes = ["deps", "srcs", "data"],
         ),
         EmacsLispInfo(
             source_files = ctx.files.srcs,

--- a/elisp/elisp_test.bzl
+++ b/elisp/elisp_test.bzl
@@ -89,7 +89,7 @@ def _elisp_test_impl(ctx):
         coverage_common.instrumented_files_info(
             ctx,
             source_attributes = ["srcs"],
-            dependency_attributes = ["deps", "srcs"],
+            dependency_attributes = ["deps", "srcs", "data"],
         ),
     ]
 

--- a/elisp/proto/elisp_proto_library.bzl
+++ b/elisp/proto/elisp_proto_library.bzl
@@ -78,7 +78,7 @@ def _elisp_proto_aspect_impl(target, ctx):
         coverage_common.instrumented_files_info(
             ctx,
             source_attributes = ["srcs"],
-            dependency_attributes = ["deps"],
+            dependency_attributes = ["deps", "data"],
             extensions = ["el"],
         ),
         EmacsLispInfo(


### PR DESCRIPTION
See https://bazel.build/extending/rules#code_coverage.