### PR TITLE
Have compile function return providers directly

### DIFF
--- a/elisp/elisp_library.bzl
+++ b/elisp/elisp_library.bzl
@@ -21,7 +21,7 @@ visibility("public")
 
 def _elisp_library_impl(ctx):
     """Rule implementation for the “elisp_library” rule."""
-    result = compile(
+    default_info, elisp_info = compile(
         ctx = ctx,
         srcs = ctx.files.srcs,
         deps = ctx.attr.deps,
@@ -31,24 +31,13 @@ def _elisp_library_impl(ctx):
         fatal_warnings = ctx.attr.fatal_warnings,
     )
     return [
-        DefaultInfo(
-            files = depset(direct = result.outs),
-            runfiles = result.runfiles,
-        ),
+        default_info,
         coverage_common.instrumented_files_info(
             ctx,
             source_attributes = ["srcs"],
             dependency_attributes = ["deps", "srcs", "data"],
         ),
-        EmacsLispInfo(
-            source_files = ctx.files.srcs,
-            compiled_files = result.outs,
-            load_path = result.load_path,
-            data_files = ctx.files.data,
-            transitive_source_files = result.transitive_srcs,
-            transitive_compiled_files = result.transitive_outs,
-            transitive_load_path = result.transitive_load_path,
-        ),
+        elisp_info,
     ]
 
 elisp_library = rule(

--- a/elisp/proto/elisp_proto_library.bzl
+++ b/elisp/proto/elisp_proto_library.bzl
@@ -65,7 +65,7 @@ def _elisp_proto_aspect_impl(target, ctx):
     if ctx.label.package == "src/google/protobuf":
         # See the comment in _elisp_proto_feature why we’re doing this.
         load_path.append(".")
-    result = compile(
+    _default_info, elisp_info = compile(
         ctx = ctx,
         srcs = srcs + [bundle],
         deps = [ctx.attr._protobuf_lib] + ctx.rule.attr.deps,
@@ -81,19 +81,11 @@ def _elisp_proto_aspect_impl(target, ctx):
             dependency_attributes = ["deps", "data"],
             extensions = ["el"],
         ),
-        EmacsLispInfo(
-            source_files = srcs + [bundle],
-            compiled_files = result.outs,
-            load_path = result.load_path,
-            data_files = ctx.rule.files.data,
-            transitive_source_files = result.transitive_srcs,
-            transitive_compiled_files = result.transitive_outs,
-            transitive_load_path = result.transitive_load_path,
-        ),
+        elisp_info,
         _ElispProtoInfo(
             # FIXME: This relies on the order of the files in result.outs.
-            files = srcs + result.outs[:-1],
-            bundle_files = [bundle] + result.outs[-1:],
+            files = srcs + elisp_info.compiled_files[:-1],
+            bundle_files = [bundle] + elisp_info.compiled_files[-1:],
         ),
     ]
 


### PR DESCRIPTION
This removes the unnecessary intermediate struct.