### PR TITLE
Remove unnecessary “_repository” suffix

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,9 +43,9 @@ cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_exten
 use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")
 
 # Non-module dependencies
-emacs_repository = use_repo_rule("//elisp/private:emacs_repository.bzl", "emacs_repository")
+emacs = use_repo_rule("//elisp/private:emacs.bzl", "emacs")
 
-emacs_repository(
+emacs(
     name = "gnu_emacs_29",
     format = "tar.xz",
     integrity = "sha384-1LIwxBtAr9RzK3VJ359OfOh/PN83fyfl7uckmMw+Z0mKabbOOsvy00PhXvm5wJtf",
@@ -57,7 +57,7 @@ emacs_repository(
     ],
 )
 
-emacs_repository(
+emacs(
     name = "gnu_emacs_windows_29",
     format = "zip",
     integrity = "sha384-wu5kKCCMX6BLgSoUfMEUf1gLk4Ua+rWa8mldAeW+Y6q+RXyCmdPZP/XuJPO9uWrt",
@@ -73,7 +73,7 @@ emacs_repository(
     ],
 )
 
-emacs_repository(
+emacs(
     name = "gnu_emacs_30",
     format = "tar.xz",
     integrity = "sha384-2hDJF2LcSpB7ZTLRyCpYBkXpMs1QVlANlrSPNfU6sUrrs57Q+7QY3Ff7MIYRwNRt",
@@ -85,7 +85,7 @@ emacs_repository(
     ],
 )
 
-emacs_repository(
+emacs(
     name = "gnu_emacs_windows_30",
     format = "zip",
     integrity = "sha384-MeW1g2s6e5UBWMBYEU+FCMeLnZMKaiBo6BWfc4Re/Dy//JBaN7RXRJtzXLq9QTSg",
@@ -101,9 +101,9 @@ emacs_repository(
     ],
 )
 
-local_emacs_repository = use_repo_rule("//elisp/private:local_emacs_repository.bzl", "local_emacs_repository")
+local_emacs = use_repo_rule("//elisp/private:local_emacs.bzl", "local_emacs")
 
-local_emacs_repository(name = "local_emacs")
+local_emacs(name = "local_emacs")
 
 junit_xsd = use_repo_rule("//private:junit_xsd.bzl", "junit_xsd")
 

--- a/elisp/private/BUILD
+++ b/elisp/private/BUILD
@@ -263,8 +263,8 @@ bzl_library(
 )
 
 bzl_library(
-    name = "emacs_repository",
-    srcs = ["emacs_repository.bzl"],
+    name = "emacs",
+    srcs = ["emacs.bzl"],
     deps = ["@bazel_tools//tools/build_defs/repo:utils.bzl"],
 )
 
@@ -279,8 +279,8 @@ bzl_library(
 )
 
 bzl_library(
-    name = "local_emacs_repository",
-    srcs = ["local_emacs_repository.bzl"],
+    name = "local_emacs",
+    srcs = ["local_emacs.bzl"],
 )
 
 bzl_library(

--- a/elisp/private/emacs.bzl
+++ b/elisp/private/emacs.bzl
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Defines the `emacs_repository` repository rule."""
+"""Defines the `emacs` repository rule."""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "get_auth")
 
 visibility("private")
 
-def _emacs_repository_impl(ctx):
+def _emacs_impl(ctx):
     urls = ctx.attr.urls
     ctx.download_and_extract(
         integrity = ctx.attr.integrity or fail("archive integrity missing"),
@@ -44,7 +44,7 @@ def _emacs_repository_impl(ctx):
         executable = False,
     )
 
-emacs_repository = repository_rule(
+emacs = repository_rule(
     # @unsorted-dict-items
     attrs = {
         "urls": attr.string_list(mandatory = True, allow_empty = False),
@@ -56,5 +56,5 @@ emacs_repository = repository_rule(
         "type": attr.string(mandatory = True, values = ["source", "release"]),
         "target_compatible_with": attr.label_list(),
     },
-    implementation = _emacs_repository_impl,
+    implementation = _emacs_impl,
 )

--- a/elisp/private/local_emacs.bzl
+++ b/elisp/private/local_emacs.bzl
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Defines the `local_emacs_repository` repository rule."""
+"""Defines the `local_emacs` repository rule."""
 
 visibility("private")
 
-def _local_emacs_repository_impl(ctx):
+def _local_emacs_impl(ctx):
     windows = ctx.os.name.startswith("windows")
     emacs = ctx.getenv("EMACS", "emacs")
     if windows and not emacs.lower().endswith(".exe"):
@@ -40,7 +40,7 @@ def _local_emacs_repository_impl(ctx):
         executable = False,
     )
 
-local_emacs_repository = repository_rule(
-    implementation = _local_emacs_repository_impl,
+local_emacs = repository_rule(
+    implementation = _local_emacs_impl,
     local = True,
 )


### PR DESCRIPTION
This shortens the generated repository names somewhat.