### PR TITLE
Rename “gnu_emacs_” prefix to just “emacs_”

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,7 @@ use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")
 emacs = use_repo_rule("//elisp/private:emacs.bzl", "emacs")
 
 emacs(
-    name = "gnu_emacs_29",
+    name = "emacs_29",
     format = "tar.xz",
     integrity = "sha384-1LIwxBtAr9RzK3VJ359OfOh/PN83fyfl7uckmMw+Z0mKabbOOsvy00PhXvm5wJtf",
     strip_prefix = "emacs-29.4",
@@ -58,7 +58,7 @@ emacs(
 )
 
 emacs(
-    name = "gnu_emacs_windows_29",
+    name = "emacs_windows_29",
     format = "zip",
     integrity = "sha384-wu5kKCCMX6BLgSoUfMEUf1gLk4Ua+rWa8mldAeW+Y6q+RXyCmdPZP/XuJPO9uWrt",
     strip_prefix = "",
@@ -74,7 +74,7 @@ emacs(
 )
 
 emacs(
-    name = "gnu_emacs_30",
+    name = "emacs_30",
     format = "tar.xz",
     integrity = "sha384-2hDJF2LcSpB7ZTLRyCpYBkXpMs1QVlANlrSPNfU6sUrrs57Q+7QY3Ff7MIYRwNRt",
     strip_prefix = "emacs-30.2",
@@ -86,7 +86,7 @@ emacs(
 )
 
 emacs(
-    name = "gnu_emacs_windows_30",
+    name = "emacs_windows_30",
     format = "zip",
     integrity = "sha384-MeW1g2s6e5UBWMBYEU+FCMeLnZMKaiBo6BWfc4Re/Dy//JBaN7RXRJtzXLq9QTSg",
     strip_prefix = "",

--- a/elisp/BUILD
+++ b/elisp/BUILD
@@ -95,22 +95,22 @@ elisp_toolchain(
 
 elisp_toolchain(
     name = "emacs_29",
-    emacs = "@gnu_emacs_29//:emacs",
+    emacs = "@emacs_29//:emacs",
 )
 
 elisp_toolchain(
     name = "emacs_29_windows_x86_64",
-    emacs = "@gnu_emacs_windows_29//:emacs",
+    emacs = "@emacs_windows_29//:emacs",
 )
 
 elisp_toolchain(
     name = "emacs_30",
-    emacs = "@gnu_emacs_30//:emacs",
+    emacs = "@emacs_30//:emacs",
 )
 
 elisp_toolchain(
     name = "emacs_30_windows_x86_64",
-    emacs = "@gnu_emacs_windows_30//:emacs",
+    emacs = "@emacs_windows_30//:emacs",
 )
 
 bzl_library(

--- a/emacs/BUILD
+++ b/emacs/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 Google LLC
+# Copyright 2020-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@ alias(
 alias(
     name = "module_header",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_30//:module_header",
-        "//conditions:default": "@gnu_emacs_30//:module_header",
+        "@platforms//os:windows": "@emacs_windows_30//:module_header",
+        "//conditions:default": "@emacs_30//:module_header",
     }),
     visibility = ["//visibility:public"],
 )
@@ -42,8 +42,8 @@ alias(
 alias(
     name = "emacs_29",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_29//:emacs",
-        "//conditions:default": "@gnu_emacs_29//:emacs",
+        "@platforms//os:windows": "@emacs_windows_29//:emacs",
+        "//conditions:default": "@emacs_29//:emacs",
     }),
     visibility = ["//visibility:public"],
 )
@@ -51,8 +51,8 @@ alias(
 alias(
     name = "emacs_30",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_30//:emacs",
-        "//conditions:default": "@gnu_emacs_30//:emacs",
+        "@platforms//os:windows": "@emacs_windows_30//:emacs",
+        "//conditions:default": "@emacs_30//:emacs",
     }),
     visibility = ["//visibility:public"],
 )

--- a/gazelle/elisp/BUILD
+++ b/gazelle/elisp/BUILD
@@ -102,7 +102,7 @@ copy_file(
 alias(
     name = "builtin_features",
     actual = select({
-        "@platforms//os:windows": "@gnu_emacs_windows_30//:builtin_features",
-        "//conditions:default": "@gnu_emacs_30//:builtin_features",
+        "@platforms//os:windows": "@emacs_windows_30//:builtin_features",
+        "//conditions:default": "@emacs_30//:builtin_features",
     }),
 )


### PR DESCRIPTION
We don’t support any non-GNU Emacsen anyway, so the prefix is superfluous.