### PR TITLE
Remove /std:c11 on Windows

### DIFF
--- a/c-std.bazelrc
+++ b/c-std.bazelrc
@@ -1,4 +1,4 @@
-# Copyright 2023, 2025 Google LLC
+# Copyright 2023, 2025, 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ common --enable_platform_specific_config
 # Specify options that might modify code generation here instead of BUILD or
 # Starlark files.  See
 # https://github.com/abseil/abseil-cpp/blob/master/FAQ.md#how-to-i-set-the-c-dialect-used-to-build-abseil.
-build:windows --conlyopt='/std:c11' --host_conlyopt='/std:c11'
 
 # Local Variables:
 # mode: bazelrc


### PR DESCRIPTION
rules_cc now specifies /std:c17 by default,
cf. https://github.com/bazelbuild/rules_cc/pull/480.