### PR TITLE
Revert "Prepare for specifying the C standard in .bazelrc"

### DIFF
--- a/elisp/toolchains/elisp_emacs_binary.bzl
+++ b/elisp/toolchains/elisp_emacs_binary.bzl
@@ -215,7 +215,6 @@ def _install(ctx, shell_toolchain, cc_toolchain, readme):
     args.add_joined(
         cflags,
         join_with = " ",
-        map_each = _munge_msvc_flag,
         omit_if_empty = False,
         expand_directories = False,
     )
@@ -315,10 +314,6 @@ def _builtin_features(actions, extract, srcs, out):
             "supports-path-mapping": "",
         },
     )
-
-def _munge_msvc_flag(s):
-    # Crude way to work around specifying Visual C++ options in .bazelrc.
-    return s.replace("/std:c", "-std=gnu")
 
 def _is_lisp_source(file, type):
     if file.extension != "el":


### PR DESCRIPTION
This reverts commit 978e492e547dddc1d171a0c38f55d8380044ab0a.

We don't specify the C standard in .bazelrc any more.