### PR TITLE
Revert "Add a workaround for https://github.com/llvm/llvm-project/issues/121984"

### DIFF
--- a/private/cc_config.bzl
+++ b/private/cc_config.bzl
@@ -50,12 +50,6 @@ COPTS = select({
 }) + select({
     Label("@rules_cc//cc/compiler:clang"): [
         "-Wno-nullability-extension",
-        # Work around https://github.com/llvm/llvm-project/issues/121984 and
-        # https://github.com/bazelbuild/rules_cc/issues/729.
-        "--system-header-prefix=absl/",
-        "--system-header-prefix=google/",
-        "--system-header-prefix=tools/",
-        "--system-header-prefix=upb/",
     ],
     Label("//conditions:default"): [],
 }) + select({


### PR DESCRIPTION


This reverts commit 4ed697d372668179d68292bbafbfdeac27ab8eed.

rules_cc issue https://github.com/bazelbuild/rules_cc/issues/729 has been fixed, so this workaround should no longer be necessary.