### PR TITLE
Print arguments passed to “bazel run”

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -59,6 +59,7 @@ runs:
           build --incompatible_strict_action_env
           build --toolchain_resolution_debug=//elisp/runfiles:runfiles
           test --test_output=errors
+          run --noomit_run_args
           ${{
             inputs.bazel-version == 'default' &&
             'common --incompatible_enforce_starlark_utf8=error' || ''

--- a/update_lockfiles
+++ b/update_lockfiles
@@ -39,6 +39,7 @@ for dir in . examples/ext; do
   bazel run \
     --lockfile_mode=off \
     --norun_validations \
+    --noomit_run_args \
     -- \
     @phst_merge_bazel_lockfiles//:merge \
     --linux-amd64="${linux:?}" \

--- a/update_readme
+++ b/update_readme
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2020-2025 Google LLC
+# Copyright 2020-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bazel run -- @update-workspace-snippets -- docs/manual.org
+bazel run --noomit_run_args -- @update-workspace-snippets -- docs/manual.org


### PR DESCRIPTION
We never pass anything sensitive on the command line, and printing these arguments on the CI logs helps with debugging.