### PR TITLE
Use a more distinctive repository name in test data

### DIFF
--- a/gazelle/testdata/update/BUILD.in
+++ b/gazelle/testdata/update/BUILD.in
@@ -1,5 +1,5 @@
 proto_library(name = "my_proto", srcs = ["my.proto"])
-load("@rules_elisp//elisp:elisp_library.bzl", "elisp_library")
+load("@my_rules_elisp//elisp:elisp_library.bzl", "elisp_library")
 some_rule(name = "module")
 # gazelle:resolve elisp module :module
 

--- a/gazelle/testdata/update/BUILD.out
+++ b/gazelle/testdata/update/BUILD.out
@@ -1,7 +1,7 @@
-load("@rules_elisp//elisp:elisp_library.bzl", "elisp_library")
-load("@rules_elisp//elisp:elisp_manual.bzl", "elisp_manual")
-load("@rules_elisp//elisp:elisp_test.bzl", "elisp_test")
-load("@rules_elisp//elisp/proto:elisp_proto_library.bzl", "elisp_proto_library")
+load("@my_rules_elisp//elisp:elisp_library.bzl", "elisp_library")
+load("@my_rules_elisp//elisp:elisp_manual.bzl", "elisp_manual")
+load("@my_rules_elisp//elisp:elisp_test.bzl", "elisp_test")
+load("@my_rules_elisp//elisp/proto:elisp_proto_library.bzl", "elisp_proto_library")
 
 proto_library(
     name = "my_proto",

--- a/gazelle/testdata/update/MODULE.bazel
+++ b/gazelle/testdata/update/MODULE.bazel
@@ -14,4 +14,4 @@
 
 module(name = "test")
 
-bazel_dep(name = "phst_rules_elisp", repo_name = "rules_elisp")
+bazel_dep(name = "phst_rules_elisp", repo_name = "my_rules_elisp")

--- a/gazelle/testdata/update/a/b/BUILD.out
+++ b/gazelle/testdata/update/a/b/BUILD.out
@@ -1,4 +1,4 @@
-load("@rules_elisp//elisp:elisp_library.bzl", "elisp_library")
+load("@my_rules_elisp//elisp:elisp_library.bzl", "elisp_library")
 
 elisp_library(
     name = "lib_3",

--- a/gazelle/testdata/update/pkg/BUILD.out
+++ b/gazelle/testdata/update/pkg/BUILD.out
@@ -1,4 +1,4 @@
-load("@rules_elisp//elisp:elisp_library.bzl", "elisp_library")
+load("@my_rules_elisp//elisp:elisp_library.bzl", "elisp_library")
 
 elisp_library(
     name = "lib_2",


### PR DESCRIPTION
We want to eventually rename phst_rules_elisp to just rules_elisp, so use a different repository name in the Gazelle test data.