### PR TITLE
Revert "Don’t require locally-installed ‘update-workspace-snippets’."

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -154,13 +154,6 @@ bazel_dep(name = "wolfd_bazel_compile_commands", version = "0.5.2", dev_dependen
 # Bogus versions added because of
 # https://github.com/renovatebot/renovate/issues/33476.
 # FIXME: Remove them once Renovate issue is fixed.
-bazel_dep(name = "phst_update_workspace_snippets", version = "0", dev_dependency = True, repo_name = "update-workspace-snippets")
-git_override(
-    module_name = "phst_update_workspace_snippets",
-    commit = "e363cf2288ac663850e2e45888cfd5bafa199335",
-    remote = "https://github.com/phst/update-workspace-snippets.git",
-)
-
 bazel_dep(name = "phst_merge_bazel_lockfiles", version = "0", dev_dependency = True)
 git_override(
     module_name = "phst_merge_bazel_lockfiles",


### PR DESCRIPTION
This reverts commit 8a2ef8b5f22015274254d61bf3a89e5850b82cea.

We don't need this dependency any more.