### PR TITLE
Revert "Use license_test repository to run addlicense"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -138,17 +138,11 @@ use_repo(
     "com_github_yuin_goldmark",
     "org_golang_google_protobuf",
     "org_golang_x_text",
+    addlicense = "com_github_google_addlicense",
 )
 
 # Tools for development
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.3", dev_dependency = True, repo_name = "buildifier")
-bazel_dep(name = "phst_license_test", version = "0", dev_dependency = True)
-git_override(
-    module_name = "phst_license_test",
-    commit = "6c1ef186ecce537f0ce25f4cb43ab45628631c86",
-    remote = "https://github.com/phst/license_test.git",
-)
-
 bazel_dep(name = "wolfd_bazel_compile_commands", version = "0.5.2", dev_dependency = True)
 
 # Bogus versions added because of

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ check-extra:
 	  -- '*/BUILD' '*/BUILD.bazel' ':^/examples/ext/'
 	$(GIT) grep -I -r -E -l -z -e '^#!/' -- ':^*.ps1' | \
 	  xargs -t -r -0 -- $(SHELLCHECK) $(SHELLCHECKFLAGS) --
+        # Find files without license headers.
+	$(BAZEL) run $(BAZELFLAGS) -- @addlicense --check \
+	  --ignore='**/index.html' --ignore='**/coverage-report/**' -- "$${PWD}"
 
 BENCHMARK_BAZELFLAGS = $(BAZELFLAGS) --lockfile_mode=off --compilation_mode=opt
 

--- a/dev/BUILD
+++ b/dev/BUILD
@@ -15,7 +15,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@buildifier//:rules.bzl", "buildifier_test")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary", "gazelle_test")
-load("@phst_license_test//:def.bzl", "license_test")
 load("@rules_go//go:def.bzl", "TOOLS_NOGO", "nogo")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
 
@@ -35,17 +34,6 @@ buildifier_test(
     lint_warnings = ["all"],
     no_sandbox = True,
     workspace = "//:MODULE.bazel",
-)
-
-license_test(
-    name = "license_test",
-    size = "medium",
-    timeout = "short",
-    ignore = [
-        "coverage-report/**",
-        "index.html",
-    ],
-    marker = "//:MODULE.bazel",
 )
 
 nogo(

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/bazelbuild/bazel-gazelle v0.52.2
 	github.com/bazelbuild/buildtools v0.0.0-20260716142318-04cf7de1434f
 	github.com/bazelbuild/rules_go v0.62.0
+	github.com/google/addlicense v1.1.1
 	github.com/google/go-cmp v0.7.0
 	github.com/yuin/goldmark v1.8.5
 	golang.org/x/text v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,9 @@ github.com/bazelbuild/rules_go v0.61.0/go.mod h1:6YghDRf6l3FSiAwncK+Ww9jE1naoQzN
 github.com/bazelbuild/rules_go v0.61.1 h1:F7jqdw0Zp/RtWFDbLFuVa2DaPjUQkqZOLCns8vCxSWg=
 github.com/bazelbuild/rules_go v0.61.1/go.mod h1:6YghDRf6l3FSiAwncK+Ww9jE1naoQzNq28gaKJeB67I=
 github.com/bazelbuild/rules_go v0.62.0/go.mod h1:6YghDRf6l3FSiAwncK+Ww9jE1naoQzNq28gaKJeB67I=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/google/addlicense v1.1.1 h1:jpVf9qPbU8rz5MxKo7d+RMcNHkqxi4YJi/laauX4aAE=
+github.com/google/addlicense v1.1.1/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Philipp Stephani
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// See
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// and
+// https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md.
+
+//go:build tools
+
+package tools
+
+import _ "github.com/google/addlicense"


### PR DESCRIPTION
This reverts commit 7860d4512e4b38932c267e5e88ce6112e4251b2e.

license_tests adds an unnecessary tiny dependency and lots of noise.