### PR TITLE
Don’t pass --noomit_run_args to older Bazel versions

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -59,7 +59,10 @@ runs:
           build --incompatible_strict_action_env
           build --toolchain_resolution_debug=//elisp/runfiles:runfiles
           test --test_output=errors
-          run --noomit_run_args
+          ${{
+            inputs.bazel-version == 'default' &&
+            'run --noomit_run_args' || ''
+          }}
           ${{
             inputs.bazel-version == 'default' &&
             'common --incompatible_enforce_starlark_utf8=error' || ''


### PR DESCRIPTION
It was introduced in Bazel 9.