### PR TITLE
Don’t rename repository for addlicense

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -134,11 +134,11 @@ go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,
     "com_github_bazelbuild_buildtools",
+    "com_github_google_addlicense",
     "com_github_google_go_cmp",
     "com_github_yuin_goldmark",
     "org_golang_google_protobuf",
     "org_golang_x_text",
-    addlicense = "com_github_google_addlicense",
 )
 
 # Tools for development


### PR DESCRIPTION
Now that we run addlicense through “go tool”, this is no longer useful.