### PR TITLE
Match MODULE.bazel filename

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,8 @@
   "packageRules": [
     {
       "enabled": false,
-      "matchDepTypes": [
-        "bazel_dep"
-      ],
-      "matchManagers": [
-        "bazel-module"
+      "matchFileNames": [
+        "MODULE.bazel"
       ]
     }
   ]


### PR DESCRIPTION
This is simpler than trying to match on the manager name and dependency type, and enables factoring out development-only dependencies.