### PR TITLE
Move development-only dependencies into an included file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,14 +29,6 @@ bazel_dep(name = "abseil-cpp", version = "20250814.2")
 bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
 bazel_dep(name = "protobuf", version = "35.1")
 
-# Development-only module dependencies
-bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.62.0", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.52.2", dev_dependency = True)
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.2", dev_dependency = True)
-bazel_dep(name = "bazel_features", version = "1.51.0", dev_dependency = True)
-bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
-
 # Bring in the local_config_cc repository.  It’s needed for
 # //emacs:windows_cc_toolchain.
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
@@ -105,13 +97,6 @@ local_emacs = use_repo_rule("//elisp/private:local_emacs.bzl", "local_emacs")
 
 local_emacs(name = "local_emacs")
 
-junit_xsd = use_repo_rule("//private:junit_xsd.bzl", "junit_xsd")
-
-junit_xsd(
-    name = "junit_xsd",
-    dev_dependency = True,
-)
-
 # Local toolchains.  We only register toolchains for the most recent Emacs
 # release, with binary builds coming first.  Source builds will be selected as a
 # fallback in case none of the binary ones apply.
@@ -121,42 +106,7 @@ register_toolchains(
 )
 
 # C++-specific dependencies
-bazel_dep(name = "gazelle_cc", version = "0.6.0", dev_dependency = True)
-
 register_toolchains("@local_config_cc_toolchains//:all")
 
-# Go-specific dependencies
-go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
-go_sdk.nogo(nogo = "//dev:nogo")
-
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
-go_deps.from_file(go_mod = "//:go.mod")
-use_repo(
-    go_deps,
-    "com_github_bazelbuild_buildtools",
-    "com_github_google_addlicense",
-    "com_github_google_go_cmp",
-    "com_github_yuin_goldmark",
-    "org_golang_google_protobuf",
-    "org_golang_x_text",
-)
-
-# Tools for development
-bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.3", dev_dependency = True, repo_name = "buildifier")
-bazel_dep(name = "wolfd_bazel_compile_commands", version = "0.5.2", dev_dependency = True)
-
-# Local binaries that need to be installed on the host/exec machine.
-local_config = use_repo_rule("//dev:local_config.bzl", "local_config")
-
-local_config(
-    name = "local_config",
-    dev_dependency = True,
-)
-
-# We want to test the external example without adding its repository to the
-# registry.  So we override the dependency immediately locally.
-bazel_dep(name = "rules_elisp_example", dev_dependency = True)
-local_path_override(
-    module_name = "rules_elisp_example",
-    path = "examples/ext",
-)
+# Development-only dependencies
+include("//:dev.MODULE.bazel")

--- a/dev.MODULE.bazel
+++ b/dev.MODULE.bazel
@@ -1,0 +1,70 @@
+# Copyright 2023-2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Development-only dependencies for rules_elisp."""
+
+# Development-only module dependencies
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.62.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.52.2", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.2", dev_dependency = True)
+bazel_dep(name = "bazel_features", version = "1.51.0", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
+
+# Non-module dependencies
+junit_xsd = use_repo_rule("//private:junit_xsd.bzl", "junit_xsd")
+
+junit_xsd(
+    name = "junit_xsd",
+    dev_dependency = True,
+)
+
+# C++-specific dependencies
+bazel_dep(name = "gazelle_cc", version = "0.6.0", dev_dependency = True)
+
+# Go-specific dependencies
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk.nogo(nogo = "//dev:nogo")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_google_addlicense",
+    "com_github_google_go_cmp",
+    "com_github_yuin_goldmark",
+    "org_golang_google_protobuf",
+    "org_golang_x_text",
+)
+
+# Tools for development
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.3", dev_dependency = True, repo_name = "buildifier")
+bazel_dep(name = "wolfd_bazel_compile_commands", version = "0.5.2", dev_dependency = True)
+
+# Local binaries that need to be installed on the host/exec machine.
+local_config = use_repo_rule("//dev:local_config.bzl", "local_config")
+
+local_config(
+    name = "local_config",
+    dev_dependency = True,
+)
+
+# We want to test the external example without adding its repository to the
+# registry.  So we override the dependency immediately locally.
+bazel_dep(name = "rules_elisp_example", dev_dependency = True)
+local_path_override(
+    module_name = "rules_elisp_example",
+    path = "examples/ext",
+)


### PR DESCRIPTION
This reduces clutter and will allow Renovate to update development-only dependencies again.