### PR TITLE
Re-enable coverage on macOS

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -68,12 +68,8 @@ jobs:
         # https://github.com/bazelbuild/bazel/issues/6374,
         # https://github.com/bazelbuild/bazel/issues/15835, and
         # https://github.com/bazelbuild/bazel/issues/18839 are fixed.
-        run: >
-          ./check.ps1
-          -Coverage:$${{
-            runner.os != 'Windows' &&
-            (runner.os != 'macOS' || matrix.cc != 'gcc')
-          }}
+        run: |
+          ./check.ps1 -Coverage:$${{runner.os != 'Windows'}}
       - name: Run OS-independent checks
         if: runner.os == 'Linux'
         shell: bash


### PR DESCRIPTION
It should work fine with Clang on macOS, and we don’t support GCC there any longer.