### PR TITLE
Remove legacy CC_TOOLCHAIN_ATTRS

### DIFF
--- a/elisp/elisp_binary.bzl
+++ b/elisp/elisp_binary.bzl
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 Google LLC
+# Copyright 2020-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 """Defines the `elisp_binary` rule."""
 
-load("@rules_cc//cc:use_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "use_cc_toolchain")
+load("@rules_cc//cc:use_cc_toolchain.bzl", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//elisp/common:elisp_info.bzl", "EmacsLispInfo")
 load("//elisp/private:binary.bzl", "binary")
@@ -49,10 +49,8 @@ def _elisp_binary_impl(ctx):
     ]
 
 elisp_binary = rule(
-    # FIXME: Remove CC_TOOLCHAIN_ATTRS once
-    # https://github.com/bazelbuild/bazel/issues/7260 is fixed.
     # @unsorted-dict-items
-    attrs = CC_TOOLCHAIN_ATTRS | COMPILE_ATTRS | {
+    attrs = COMPILE_ATTRS | {
         "src": attr.label(
             doc = "Source file to load.",
             allow_single_file = [".el"],

--- a/elisp/elisp_cc_module.bzl
+++ b/elisp/elisp_cc_module.bzl
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 Google LLC
+# Copyright 2020-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 """Defines the `elisp_cc_module` rule."""
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
-load("@rules_cc//cc:use_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "use_cc_toolchain")
+load("@rules_cc//cc:use_cc_toolchain.bzl", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//elisp/common:elisp_info.bzl", "EmacsLispInfo")
@@ -141,10 +141,8 @@ using
 ```
 
 to implement module functions.""",
-    # FIXME: Remove CC_TOOLCHAIN_ATTRS once
-    # https://github.com/bazelbuild/bazel/issues/7260 is fixed.
     # @unsorted-dict-items
-    attrs = CC_TOOLCHAIN_ATTRS | {
+    attrs = {
         "srcs": attr.label_list(
             doc = """C and C++ source files for the module.
 See the [corresponding attribute for

--- a/elisp/elisp_test.bzl
+++ b/elisp/elisp_test.bzl
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 Google LLC
+# Copyright 2020-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 """Defines the `elisp_test` rule."""
 
-load("@rules_cc//cc:use_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "use_cc_toolchain")
+load("@rules_cc//cc:use_cc_toolchain.bzl", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//elisp/common:elisp_info.bzl", "EmacsLispInfo")
 load("//elisp/private:binary.bzl", "binary")
@@ -91,10 +91,8 @@ def _elisp_test_impl(ctx):
     ]
 
 elisp_test = rule(
-    # FIXME: Remove CC_TOOLCHAIN_ATTRS once
-    # https://github.com/bazelbuild/bazel/issues/7260 is fixed.
     # @unsorted-dict-items
-    attrs = CC_TOOLCHAIN_ATTRS | COMPILE_ATTRS | {
+    attrs = COMPILE_ATTRS | {
         "srcs": attr.label_list(
             allow_empty = False,
             doc = "List of source files to load.",

--- a/elisp/toolchains/elisp_emacs_binary.bzl
+++ b/elisp/toolchains/elisp_emacs_binary.bzl
@@ -17,7 +17,7 @@ Bazel."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:action_names.bzl", "CPP_LINK_EXECUTABLE_ACTION_NAME", "C_COMPILE_ACTION_NAME")
-load("@rules_cc//cc:use_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "use_cc_toolchain")
+load("@rules_cc//cc:use_cc_toolchain.bzl", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//elisp/private:cc_default_info.bzl", "CcDefaultInfo")
@@ -69,10 +69,8 @@ def _elisp_emacs_binary_impl(ctx):
     ]
 
 elisp_emacs_binary = rule(
-    # FIXME: Remove CC_TOOLCHAIN_ATTRS once
-    # https://github.com/bazelbuild/bazel/issues/7260 is fixed.
     # @unsorted-dict-items
-    attrs = CC_TOOLCHAIN_ATTRS | LAUNCHER_ATTRS | {
+    attrs = LAUNCHER_ATTRS | {
         "mode": attr.string(
             doc = """How to build and install Emacs.  Possible values are:
 - `source`: Build Emacs from sources using `configure` and `make install`.


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/7260 has been fixed a while ago, and all supported Bazel versions (8 and upwards) use the new toolchain mechanism, cf. https://github.com/bazelbuild/bazel/commit/e116bae8213ca31ae590a60748c1b6d505a4f819.