### PR TITLE
Revert "Specify host fragments in addition to target fragments"

### DIFF
--- a/elisp/elisp_binary.bzl
+++ b/elisp/elisp_binary.bzl
@@ -99,7 +99,6 @@ The source file is byte-compiled.  At runtime, the compiled version is loaded
 in batch mode unless `interactive` is `True`.""",
     executable = True,
     fragments = ["cpp"],
-    host_fragments = ["cpp"],
     toolchains = use_cc_toolchain() + [Label("//elisp:toolchain_type")],
     implementation = _elisp_binary_impl,
 )

--- a/elisp/elisp_cc_module.bzl
+++ b/elisp/elisp_cc_module.bzl
@@ -193,7 +193,6 @@ C/C++ compiler.  See the [corresponding attribute for
     },
     provides = [EmacsLispInfo],
     fragments = ["cpp"],
-    host_fragments = ["cpp"],
     toolchains = use_cc_toolchain(),
     implementation = _elisp_cc_module_impl,
 )

--- a/elisp/elisp_test.bzl
+++ b/elisp/elisp_test.bzl
@@ -170,7 +170,6 @@ variable.  After processing known arguments, test files must remove them from
 Emacs will not automatically process these arguments using
 `command-switch-alist` or `command-line-functions`.""",
     fragments = ["cpp"],
-    host_fragments = ["cpp"],
     test = True,
     toolchains = use_cc_toolchain() + [Label("//elisp:toolchain_type")],
     implementation = _elisp_test_impl,

--- a/elisp/toolchains/elisp_emacs_binary.bzl
+++ b/elisp/toolchains/elisp_emacs_binary.bzl
@@ -142,7 +142,6 @@ This is used by Gazelle.""",
 The resulting executable can be used to run the compiled Emacs.""",
     executable = True,
     fragments = ["cpp"],
-    host_fragments = ["cpp"],
     toolchains = use_cc_toolchain() + [Label("@rules_shell//shell:toolchain_type")],
     implementation = _elisp_emacs_binary_impl,
 )


### PR DESCRIPTION
This reverts commit 87867633a4ea7bc637367129bb6d9a5cff3c9b9c.

It’s unclear why we would need host_fragments in the first place.