### PR TITLE
Don’t run validations when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ADDLICENSE = $(GO) tool addlicense
 GOMODZIP = $(GO) tool gomodzip
 
 all:
-	$(BAZEL) build $(BAZELFLAGS) -- //...
+	$(BAZEL) build --norun_validations $(BAZELFLAGS) -- //...
 
 generate: compdb coverage
 


### PR DESCRIPTION
The validations aren’t necessary for building, and Nogo errors sometimes mask more useful compiler errors.