### PR TITLE
Move --incompatible_enforce_starlark_utf8 flag to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,8 @@
 
 build --enable_platform_specific_config
 
+common --incompatible_enforce_starlark_utf8=error
+
 build --process_headers_in_dependencies
 
 # The external_include_paths feature has to be specified in .bazelrc because it

--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -45,10 +45,6 @@ runs:
           # --omit_run_args was added in Bazel 9.
           # FIXME: Add it unconditionally once we drop support for Bazel 8.
           ${{case(inputs.bazel-version == '', '', '# ')}}run --noomit_run_args
-          # --incompatible_enforce_starlark_utf8 was added in Bazel 8.1.
-          # FIXME: Add it to the project’s .bazelrc once we drop support for
-          # Bazel 8.0 and below.
-          ${{case(inputs.bazel-version == '', '', '# ')}}common --incompatible_enforce_starlark_utf8=error
           # See https://bazel.build/configure/windows#clang for how to configure
           # Bazel to use Clang on Windows.
           ${{


### PR DESCRIPTION
It’s present in all Bazel versions that we support.