### PR TITLE
Revert "Consistently quote arguments to work around https://github.co…

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//go:go_test.bzl", "go_test")
 load("//elisp:elisp_binary.bzl", "elisp_binary")
@@ -109,11 +108,7 @@ go_test(
     size = "medium",
     timeout = "short",
     srcs = ["bin_test.go"],
-    args = [
-        # See https://github.com/bazelbuild/bazel/issues/12313 why we need to
-        # add additional quoting.
-        shell.quote("--bin=$(rlocationpath :bin)"),
-    ],
+    args = ["--bin=$(rlocationpath :bin)"],
     data = ["bin"],
     deps = ["@rules_go//go/runfiles"],
 )


### PR DESCRIPTION
…m/bazelbuild/bazel/issues/10859"

This reverts commit f461858a87e553d268dabb02ec21dc5cf5609ded.

Partially undo the quoting introduced in
commit f461858a87e553d268dabb02ec21dc5cf5609ded: rlocationpath already quotes its result, cf. https://github.com/bazelbuild/bazel/issues/6531, so we only have to quote if the rest of the argument may contain metacharacters.