### PR TITLE
Introduce functions to properly quote $(rlocationpath) expansions

### DIFF
--- a/elisp/private/tools/BUILD
+++ b/elisp/private/tools/BUILD
@@ -25,6 +25,7 @@ load("//elisp/private:cc_launcher_config.bzl", "LAUNCHER_COPTS", "LAUNCHER_DEFIN
 load("//elisp/private:manual.bzl", "MAX_MANUAL_ADDITIONAL_INPUTS")
 load("//private:cc_config.bzl", "COPTS", "CXXOPTS", "DEFINES", "FEATURES", "LINKOPTS", "RUNFILES_LIBS")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "rlocation")
 
 package(
     default_package_metadata = ["//:license"],
@@ -264,7 +265,7 @@ cc_library(
     local_defines = DEFINES + [
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
-        shell.quote('RULES_ELISP_RUN_TST_ELC=R"*($(rlocationpath :run-tst.elc))*"'),
+        rlocation('RULES_ELISP_RUN_TST_ELC=R"*(%s)*"', ":run-tst.elc"),
     ],
     visibility = ["//elisp:__pkg__"],
     deps = [
@@ -318,7 +319,7 @@ cc_library(
     local_defines = DEFINES + [
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
-        shell.quote('RULES_ELISP_RUNFILES_ELC=R"*($(rlocationpath //elisp/runfiles:runfiles.elc))*"'),
+        rlocation('RULES_ELISP_RUNFILES_ELC=R"*(%s)*"', "//elisp/runfiles:runfiles.elc"),
     ],
     visibility = ["//tests/tools:__pkg__"],
     deps = [

--- a/gazelle/elisp/BUILD
+++ b/gazelle/elisp/BUILD
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_go//go:go_library.bzl", "go_library")
 load("@rules_go//go:go_test.bzl", "go_test")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "runfileflag")
 
 package(
     default_package_metadata = ["//:license"],
@@ -72,12 +72,9 @@ go_test(
         "integration_test.go",
         "resolve_test.go",
     ],
-    args = [
-        # See https://github.com/bazelbuild/bazel/issues/12313 why we need to
-        # add additional quoting.
-        shell.quote("--{t}=$(rlocationpath {t})".format(t = t))
-        for t in TEST_DATA
-    ],
+    # See https://github.com/bazelbuild/bazel/issues/12313 why we need to add
+    # additional quoting.
+    args = [runfileflag(t) for t in TEST_DATA],
     data = TEST_DATA + ["//gazelle/testdata"],
     deps = [
         ":elisp",

--- a/private/BUILD
+++ b/private/BUILD
@@ -82,6 +82,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "rlocation",
+    srcs = ["rlocation.bzl"],
+    deps = ["@bazel_skylib//lib:shell"],
+)
+
+bzl_library(
     name = "junit_xsd",
     srcs = ["junit_xsd.bzl"],
 )

--- a/private/rlocation.bzl
+++ b/private/rlocation.bzl
@@ -1,0 +1,64 @@
+# Copyright 2026 Philipp Stephani
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains helper functions to properly quote runfile locations."""
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+visibility([
+    # keep sorted
+    "//elisp/private/tools",
+    "//gazelle/elisp",
+    "//tests/integration",
+    "//tests/integration/wrap",
+    "//tests/proto/integration",
+    "//tests/runfiles",
+    "//tests/tools",
+])
+
+def rlocation(format, label):
+    """Splices a runfile location into the format.
+
+    <var>format</var> must contain exactly one %s sequence, which is replaced by
+    $(rlocationpath <var>label</var>).  The output is properly quoted so it can
+    be used in `args` or `defines` attributes.
+
+    Args:
+      format: a format string, must contain exactly one %s sequence
+      label: a Blaze label denoting a runfile
+
+    Returns:
+      a quoted version of
+      <code><var>format % "$(rlocationpath <var>label</var>)"</code>
+    """
+    before, sep, after = format.partition("%s")
+    if not sep or "%" in before or "%" in after:
+        fail("Invalid format string %r" % format)
+
+    # Note that rlocation already quotes its result (see
+    # https://github.com/bazelbuild/bazel/issues/6531), so we must not quote it
+    # again.
+    return shell.quote(before) + "$(rlocationpath %s)" % label + shell.quote(after)
+
+def runfileflag(label):
+    """Returns a flag string that can be used with testutil.RunfileFlag.
+
+    Args:
+      label: a Blaze label denoting a runfile
+
+    Returns:
+      a quoted string of the form
+      <code>--<var>label</var>=$(rlocationpath <var>label</var>)</code>
+    """
+    return rlocation("--%s=%%s" % label, label)

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -24,6 +24,7 @@ load("//elisp:elisp_binary.bzl", "elisp_binary")
 load("//elisp:elisp_library.bzl", "elisp_library")
 load("//elisp:elisp_test.bzl", "elisp_test")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "runfileflag")
 
 package(
     default_package_metadata = ["//:license"],
@@ -63,10 +64,7 @@ go_test(
         # See https://github.com/bazelbuild/bazel/issues/12313 why we need to
         # add additional quoting.
         shell.quote("--xmllint=" + XMLLINT),
-    ] + [
-        shell.quote("--{t}=$(rlocationpath {t})".format(t = t))
-        for t in TEST_DATA
-    ],
+    ] + [runfileflag(t) for t in TEST_DATA],
     data = TEST_DATA,
     embedsrcs = [
         "coverage.dat",

--- a/tests/integration/wrap/BUILD
+++ b/tests/integration/wrap/BUILD
@@ -19,6 +19,7 @@ load("@rules_go//go:go_binary.bzl", "go_binary")
 load("@rules_go//go:go_library.bzl", "go_library")
 load("//elisp/private:cc_launcher_config.bzl", "LAUNCHER_COPTS", "LAUNCHER_DEFINES", "LAUNCHER_DEPS", "LAUNCHER_FEATURES", "LAUNCHER_LINKOPTS")  # buildifier: disable=bzl-visibility
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "rlocation")
 
 package(
     default_package_metadata = ["//:license"],
@@ -43,7 +44,7 @@ cc_binary(
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
         shell.quote("RULES_ELISP_BINARY=1"),
-        shell.quote('RULES_ELISP_WRAPPER=RULES_ELISP_NATIVE_LITERAL(R"*($(rlocationpath :wrap))*")'),
+        rlocation('RULES_ELISP_WRAPPER=RULES_ELISP_NATIVE_LITERAL(R"*(%s)*")', ":wrap"),
         shell.quote("RULES_ELISP_MODE=rules_elisp::ToolchainMode::kWrap"),
         shell.quote('RULES_ELISP_TAGS=RULES_ELISP_NATIVE_LITERAL("local"), RULES_ELISP_NATIVE_LITERAL("mytag")'),
         shell.quote('RULES_ELISP_LOAD_PATH=RULES_ELISP_NATIVE_LITERAL("rules_elisp")'),

--- a/tests/proto/integration/BUILD
+++ b/tests/proto/integration/BUILD
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@rules_go//go:go_test.bzl", "go_test")
 load("//elisp:elisp_binary.bzl", "elisp_binary")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "runfileflag")
 
 package(
     default_package_metadata = ["//:license"],
@@ -32,12 +32,9 @@ go_test(
     name = "integration_test",
     size = "medium",
     srcs = ["module_test.go"],
-    args = [
-        # See https://github.com/bazelbuild/bazel/issues/12313 why we need to
-        # add additional quoting.
-        shell.quote("--{t}=$(rlocationpath {t})".format(t = t))
-        for t in TEST_DATA
-    ],
+    # See https://github.com/bazelbuild/bazel/issues/12313 why we need to add
+    # additional quoting.
+    args = [runfileflag(t) for t in TEST_DATA],
     data = TEST_DATA,
     deps = ["//internal/testutil"],
 )

--- a/tests/runfiles/BUILD
+++ b/tests/runfiles/BUILD
@@ -17,6 +17,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//elisp:elisp_library.bzl", "elisp_library")
 load("//elisp:elisp_test.bzl", "elisp_test")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "rlocation", "runfileflag")
 
 package(
     default_package_metadata = ["//:license"],
@@ -52,7 +53,10 @@ elisp_test(
     name = "runfiles_test",
     size = "small",
     srcs = ["runfiles-test.el"],
-    args = ["--%s=$(rlocationpath %s)" % (f, f) for f in TEST_DATA] + ["--unicode-%d=$(rlocationpath %s)" % (i, f) for i, f in enumerate(UNICODE, 1)],
+    args = [runfileflag(t) for t in TEST_DATA] + [rlocation(
+        "--unicode-%d=%%s" % i,
+        f,
+    ) for i, f in enumerate(UNICODE, 1)],
     data = TEST_DATA + UNICODE,
     deps = ["//elisp/runfiles"],
 )

--- a/tests/tools/BUILD
+++ b/tests/tools/BUILD
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_go//go:go_test.bzl", "go_test")
 load("//elisp:elisp_test.bzl", "elisp_test")
 load("//private:cc_config.bzl", "COPTS", "CXXOPTS", "DEFINES", "FEATURES", "LINKOPTS", "RUNFILES_LIBS")
 load("//private:package_features.bzl", "PACKAGE_FEATURES")
+load("//private:rlocation.bzl", "rlocation", "runfileflag")
 
 package(
     default_package_metadata = ["//:license"],
@@ -63,7 +63,7 @@ cc_test(
     local_defines = DEFINES + [
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
-        shell.quote('RULES_ELISP_RUNFILES_ELC=R"*($(rlocationpath //elisp/runfiles:runfiles.elc))*"'),
+        rlocation('RULES_ELISP_RUNFILES_ELC=R"*(%s)*"', "//elisp/runfiles:runfiles.elc"),
     ],
     deps = [
         "//elisp/private/tools:load",
@@ -130,7 +130,7 @@ cc_test(
     local_defines = DEFINES + [
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
-        shell.quote('RULES_ELISP_PROGRAM=R"*($(rlocationpath //tests:empty))*"'),
+        rlocation('RULES_ELISP_PROGRAM=R"*(%s)*"', "//tests:empty"),
     ],
     deps = [
         "//elisp/private/tools:platform",
@@ -161,8 +161,8 @@ cc_test(
     local_defines = DEFINES + [
         # See https://github.com/bazelbuild/bazel/issues/10859 why we need to
         # add additional quoting.
-        shell.quote('RULES_ELISP_DATA=R"*($(rlocationpath :BUILD))*"'),
-        shell.quote('RULES_ELISP_HELPER=R"*($(rlocationpath //tests/tools/helper))*"'),
+        rlocation('RULES_ELISP_DATA=R"*(%s)*"', ":BUILD"),
+        rlocation('RULES_ELISP_HELPER=R"*(%s)*"', "//tests/tools/helper"),
     ],
     deps = [
         "//elisp/private/tools:numeric",
@@ -213,7 +213,7 @@ go_test(
     size = "medium",
     timeout = "short",
     srcs = ["copy_tree_test.go"],
-    args = ["--%s=$(rlocationpath %s)" % (f, f) for f in TOOLS_TEST_DATA],
+    args = [runfileflag(t) for t in TOOLS_TEST_DATA],
     data = TOOLS_TEST_DATA,
     deps = [
         "//internal/testutil",


### PR DESCRIPTION
This used to be inconsistent and only accidentally worked: $(rlocationpath) expansions are already
quoted (cf. https://github.com/bazelbuild/bazel/issues/6531), and the previous approach only worked because location expansions get applied after the shell quoting.