### PR TITLE
Revert "Avoid test flakiness depending on sandbox mtimes."

### DIFF
--- a/examples/bin_test.go
+++ b/examples/bin_test.go
@@ -17,12 +17,9 @@ package bin_test
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
 )
@@ -43,6 +40,10 @@ func Example() {
 	// You can run the programs produced by elisp_binary rules like any
 	// other binary.
 	cmd := exec.Command(bin, "human")
+	cmd.Stdout = os.Stdout
+	// Note: Emacs writes to stderr, but the example runner only captures
+	// stdout.
+	cmd.Stderr = os.Stdout
 	// The working directory doesn’t matter.  Binaries still find their
 	// runfiles.
 	cmd.Dir = "/"
@@ -59,19 +60,8 @@ func Example() {
 		"GCOV_PREFIX="+tempDir,
 		"LLVM_PROFILE_FILE="+filepath.Join(tempDir, "bazel.%p.profraw"),
 	)
-	// Note: Emacs writes to stderr, but the example runner only captures
-	// stdout.
-	out, err := cmd.CombinedOutput()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		panic(err)
-	}
-	// We filter out some irrelevant messages that can cause spurious
-	// failures.
-	for line := range strings.Lines(string(out)) {
-		line := strings.TrimRight(line, "\n")
-		if !irrelevant.MatchString(line) {
-			fmt.Println(line)
-		}
 	}
 	// Output:
 	// hi from bin, ("human")
@@ -80,7 +70,3 @@ func Example() {
 	// hi from lib-1
 	// hi from data dependency
 }
-
-// This message can happen depending on the mtime of files in the Bazel
-// sandbox.  It shouldn’t influence the test outcome.
-var irrelevant = regexp.MustCompile(`^Source file .+ newer than byte-compiled file; using older file$`)


### PR DESCRIPTION
This reverts commit 959667e20fd2c93201b9f53d6ce2492d257901be.