### PR TITLE
Loop over Bazel versions in build script

### DIFF
--- a/.github/actions/set-up/action.yaml
+++ b/.github/actions/set-up/action.yaml
@@ -16,9 +16,6 @@ name: Set up Bazel workspace
 description: Install necessary dependencies and load remote caches
 
 inputs:
-  bazel:
-    description: Bazel version to use
-    required: false
   cc:
     description: C/C++ compiler to use
     required: false
@@ -37,14 +34,6 @@ runs:
       with:
         bazelrc: |
           common --config=ci
-          # The lockfile format differs between the Bazel versions, so only for
-          # one version --lockfile_mode=error can work.  --lockfile_mode=update
-          # would be useless since we never use the updated lockfiles, so switch
-          # lockfiles off entirely in other Bazel versions.
-          common --lockfile_mode=${{case(inputs.bazel == '', 'error', 'off')}}
-          # --omit_run_args was added in Bazel 9.
-          # FIXME: Add it unconditionally once we drop support for Bazel 8.
-          ${{case(inputs.bazel == '', '', '# ')}}run --noomit_run_args
           # See https://bazel.build/configure/windows#clang for how to configure
           # Bazel to use Clang on Windows.
           ${{
@@ -52,7 +41,7 @@ runs:
                  'build --config=clang-cl', '')
           }}
         # Use disk cache to speed up runs.
-        disk-cache: ${{inputs.bazel || 'default'}}-${{inputs.cc}}
+        disk-cache: ${{inputs.cc}}
         repository-cache: true
     - id: msys2
       name: Install MSYS2
@@ -107,14 +96,6 @@ runs:
           'BAZEL_SH=${{steps.msys2.outputs.msys2-location}}\usr\bin\bash.exe',
           'EMACS=${{steps.msys2.outputs.msys2-location}}\mingw64\bin\emacs.exe'
         )
-    - name: Override Bazel version
-      if: inputs.bazel
-      shell: pwsh
-      run: >-
-        Add-Content
-        -Verbose
-        -LiteralPath $Env:GITHUB_ENV
-        -Value 'USE_BAZEL_VERSION=${{inputs.bazel}}'
     - name: Override C/C++ compiler
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,12 +27,9 @@ jobs:
     name: Test
     strategy:
       matrix:
-        # We don’t use the GitHub matrix support for the Emacs toolchain to
-        # allow Bazel to cache intermediate results between the test runs.
-        bazel:
-          - '8.1.0'
-          - '8.x'
-          - ''  # use .bazelversion
+        # We don’t use the GitHub matrix support for the Emacs toolchain and the
+        # Bazel version to allow Bazel to cache intermediate results between the
+        # test runs.
         os:
           - ubuntu-latest
           - macos-latest
@@ -60,7 +57,6 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/set-up
         with:
-          bazel: ${{matrix.bazel}}
           cc: ${{matrix.cc}}
       - name: Run Bazel tests
         shell: pwsh

--- a/check.ps1
+++ b/check.ps1
@@ -22,11 +22,11 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 
 $candidates = @(
-    Get-Command -Name bazelisk, bazel -Type Application, ExternalScript
+    Get-Command -Name bazelisk -Type Application, ExternalScript
 )
 
 if (! $candidates) {
-    throw 'neither Bazelisk nor Bazel found'
+    throw 'Bazelisk not found'
 }
 
 $bazel = $candidates[0].Path
@@ -46,9 +46,17 @@ function Run-Tests {
 # All supported Emacs major versions.
 $versions = '30', '31'
 
+# Selection of supported non-default Bazel versions.
+$bazelVersions = '8.1.0', '8.x'
+
 $VerbosePreference = 'Continue'
 
 Set-Location -Path $PSScriptRoot
+
+if (Test-Path Env:USE_BAZEL_VERSION) {
+    Write-Warning -Message 'Removing environment variable USE_BAZEL_VERSION'
+    Remove-Item -Verbose -Path Env:USE_BAZEL_VERSION
+}
 
 # Test both default toolchain and versioned toolchains.
 Run-Tests
@@ -65,6 +73,27 @@ Run-Tests '--extra_toolchains=//elisp:local_toolchain'
 
 Run-Bazel 'mod' 'graph' > $null
 
+# Run the Bazel tests for all supported Bazel versions.
+foreach ($version in $bazelVersions) {
+    New-Item -Verbose -Path Env: -Name USE_BAZEL_VERSION -Value $version
+    # The lockfile format differs between the Bazel versions, so only for one
+    # version --lockfile_mode=error can work.  --lockfile_mode=update would be
+    # useless in GitHub since we never use the updated lockfiles, so switch
+    # lockfiles off entirely in other Bazel versions.
+    Run-Tests '--lockfile_mode=off'
+    Remove-Item -Verbose -Path Env:USE_BAZEL_VERSION
+}
+
 Join-Path -Path examples -ChildPath ext | Set-Location
 Run-Tests
 Run-Bazel 'mod' 'graph' > $null
+
+foreach ($version in $bazelVersions) {
+    New-Item -Verbose -Path Env: -Name USE_BAZEL_VERSION -Value $version
+    # The lockfile format differs between the Bazel versions, so only for one
+    # version --lockfile_mode=error can work.  --lockfile_mode=update would be
+    # useless in GitHub since we never use the updated lockfiles, so switch
+    # lockfiles off entirely in other Bazel versions.
+    Run-Tests '--lockfile_mode=off'
+    Remove-Item -Verbose -Path Env:USE_BAZEL_VERSION
+}


### PR DESCRIPTION
There’s too much cache thrashing on GitHub due to large action caches.  Instead of trying to parallelize runs using the GitHub matrix, run them sequentially to lower the number of caches.

Since the GitHub runners don’t have enough disk space for a full Cartesian product, only use the default Emacs toolchain for non-default Bazel versions and vice versa.  This should still provide enough coverage.